### PR TITLE
ensured the rpath was set for linux builds, removing the need to set LD_LIBRARY_PATH

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,6 +15,7 @@ stringImportPaths "res/" "./"
 preBuildCommands "dub run gitver -- --prefix INC --file source/creator/ver.d --mod creator.ver --appname \"Inochi Creator\""
 configuration "posix" {
 	targetType "executable"
+	lflags "-rpath=$$ORIGIN"
 }
 configuration "winapp" {
 	platforms "windows"


### PR DESCRIPTION
This should allow the behavior to mimic that of library loading on Windows by ensuring that when loading dynamic libraries the directory of the executable is checked first, removing the need to set LD_LIBRARY_PATH or install the libraries to the system 