### PR TITLE
Package source without restricted assets

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -164,3 +164,31 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
           files: out/inochi-creator-win32-x86_64.zip
+
+  barebones-source:
+    runs-on: ubuntu-18.04
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: 'Remove restricted assets'
+      run: |
+        rm res/logo.png
+        rm res/logo_256.png
+        rm -rf res/ui/
+        rm res/inochi-creator.ico
+        rm res/inochi-creator.rc
+
+    - name: 'Archive barebones source'
+      uses: thedoctor0/zip-release@main
+      with:
+        type: 'tar'
+        filename: 'inochi-creator-barebones-src.tar.gz'
+        directory: './'
+        path: '*'
+
+    - name: 'Release barebones source'
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+          files: 'inochi-creator-barebones-src.tar.gz'


### PR DESCRIPTION
Added a process that repackages the source removing the assets that can't be freely redistributed.

It shouldn't add too much burden to the CI and would make it easier for package maintainers.