### PR TITLE
Add appdata file and integrate to appimage

### DIFF
--- a/BuildAppImage.sh
+++ b/BuildAppImage.sh
@@ -3,12 +3,13 @@ cd build
 
 mkdir inochi-creator.AppDir
 cd inochi-creator.AppDir
-mkdir usr
-mkdir usr/bin
+mkdir -p usr/bin
+mkdir -p usr/share/metainfo
 cp ../../out/inochi-creator usr/bin/inochi-creator
 cp ../../out/*.mo ./
 cp ../../res/logo_256.png logo_256.png
 cp ../../res/inochi-creator.desktop inochi-creator.desktop
+cp ../../res/inochi-creator.appdata.xml usr/share/metainfo/inochi-creator.appdata.xml
 cp ../../res/AppRun AppRun
 cp ../../res/NotoSansCJK-Regular-LICENSE usr/bin/NotoSansCJK-Regular-LICENSE
 cp ../../res/MaterialIcons-LICENSE usr/bin/MaterialIcons-LICENSE

--- a/res/inochi-creator.appdata.xml
+++ b/res/inochi-creator.appdata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>inochi-creator</id>
+  <launchable type="desktop-id">inochi-creator.desktop</launchable>
+  <name>Inochi Creator</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-2-Clause</project_license>
+  <summary>Tool to create and edit Inochi2D puppets.</summary>
+  <description>
+    <p>
+      Inochi2D is a framework for realtime 2D puppet animation which can be used for VTubing, 
+      game development and digital animation. 
+    </p>
+    <p>
+      Inochi Creator is a tool that lets you create and edit Inochi2D puppets.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/Inochi2D/inochi-creator</url>
+  <url type="help">https://github.com/Inochi2D/inochi-creator</url>
+  <url type="bugtracker">https://github.com/Inochi2D/inochi-creator/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Title screen</caption>
+      <image>https://user-images.githubusercontent.com/7032834/170948484-2f3a8175-9c45-4cf6-ae7e-0a6ee86bdc53.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Graphics</category>
+  </categories>
+</component>


### PR DESCRIPTION
Actually I initially wrote this appstream metadata file for my COPR project, but thought it could be useful here too.

I integrated it to the AppImage script using this as reference.
https://docs.appimage.org/packaging-guide/optional/appstream.html

This is how the COPR version ends up looking on gnome-software
![image](https://user-images.githubusercontent.com/11585030/178829506-39a04b46-48b4-45f1-a9e8-aed6fb6fc8b6.png)
