### PR TITLE
Fix crash on empty parameter name

### DIFF
--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -429,6 +429,9 @@ private {
     Generates a parameter view
 */
 void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string* grabParam) {
+    igPushID(cast(void*)param);
+    scope(exit) igPopID();
+
     bool open = igCollapsingHeader(param.name.toStringz, ImGuiTreeNodeFlags.DefaultOpen);
     if(igBeginDragDropSource(ImGuiDragDropFlags.SourceAllowNullID)) {
         igSetDragDropPayload("_PARAMETER", cast(void*)&param, (&param).sizeof, ImGuiCond.Always);
@@ -438,7 +441,6 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
 
     if (!open) return;
     igIndent();
-        igPushID(cast(void*)param);
 
             float reqSpace = param.isVec2 ? 144 : 52;
 
@@ -593,7 +595,6 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
             if (incArmedParameter() == param) {
                 bindingList(param);
             }
-        igPopID();
     igUnindent();
 }
 


### PR DESCRIPTION
Having an empty parameter name for any reason caused the following crash:
```
inochi-creator: /media/modus/External2/inochi/bindbc-imgui/deps/cimgui/imgui/imgui.cpp:8925: bool ImGui::ItemAdd(const ImRect&, ImGuiID, const ImRect*, ImGuiItemFlags): Assertion `id != window->ID && "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!"' failed.
Program exited with code -6
```

```
#7  0x00005555558a09cf in ImGui::ItemAdd(ImRect const&, unsigned int, ImRect const*, int) ()
#8  0x0000555555947ac7 in ImGui::TreeNodeBehavior(unsigned int, int, char const*, char const*) ()
#9  0x00005555559487a3 in ImGui::CollapsingHeader(char const*, int) ()
#10 0x000055555586c2c4 in igCollapsingHeader_TreeNodeFlags ()
#11 0x0000555555965c9b in _D6bindbc5imgui4bindQl18igCollapsingHeaderFPxaEQBtQBpQBmQBv18ImGuiTreeNodeFlagsZb (flags=<incomplete type>, label=0x555556f01170 "")
    at ../bindbc-imgui/source/bindbc/imgui/bind/imgui.d:7483
#12 0x000055555583d1bf in _D7creator6panels10parameters__T16incParameterViewVbi0ZQxFmC8inochi2d4core5param9ParameterPAyaZv (grabParam=0x7ffff6b8e170, param=0x7ffff6b8f370, idx=2)
    at source/creator/panels/parameters.d:432
#13 0x000055555583993a in _D7creator6panels10parameters15ParametersPanel8onUpdateMFZv (this=0x7ffff6b8e100) at source/creator/panels/parameters.d:685
#14 0x00005555558359d4 in _D7creator6panels5Panel6updateMFZv (this=0x7ffff6b8e100) at source/creator/panels/package.d:116
#15 0x0000555555835b4a in _D7creator6panels15incUpdatePanelsFZv () at source/creator/panels/package.d:148
#16 0x00005555557b56a4 in _D3app9incUpdateFZv () at source/app.d:111
#17 0x00005555557b5620 in _Dmain (args=...) at source/app.d:80
```

This PR fixes the crash by moving the ID push/pop to surround the collapsing header.