### PR TITLE
Enhance undo impl3

### DIFF
--- a/source/creator/actions/drawable.d
+++ b/source/creator/actions/drawable.d
@@ -25,19 +25,19 @@ public:
     Drawable self;
     string name;
 
-    MeshData oldMesh;
-    MeshData newMesh;
+    MeshData mesh;
+    bool     undoable;
 
     this(string name, Drawable self) {
         super();
         this.name = name;
         this.self = self;
-        copy(self.getMesh(), oldMesh);
+        this.undoable = true;
+        copy(self.getMesh(), mesh);
     }
 
     override
     void updateNewState() {
-        copy(self.getMesh(), newMesh);
     }
 
     void addBinding(Parameter param, ParameterBinding binding) {
@@ -49,7 +49,13 @@ public:
     */
     override
     void rollback() {
-        self.rebuffer(oldMesh);
+        if (undoable) {
+            MeshData tmpMesh;
+            copy(self.getMesh(), tmpMesh);
+            self.rebuffer(mesh);
+            mesh = tmpMesh;
+            undoable = false;
+        }
         super.rollback();
     }
 
@@ -58,7 +64,13 @@ public:
     */
     override
     void redo() {
-        self.rebuffer(newMesh);
+        if (!undoable) {
+            MeshData tmpMesh;
+            copy(self.getMesh(), tmpMesh);
+            self.rebuffer(mesh);
+            mesh = tmpMesh;
+            undoable = true;
+        }
         super.redo();
     }
 

--- a/source/creator/actions/mesheditor.d
+++ b/source/creator/actions/mesheditor.d
@@ -113,7 +113,8 @@ class MeshEditorDeformationAction  : LazyBoundAction {
                         self.applyOffsets(deform.getValue(param.findClosestKeypoint()).vertexOffsets);            
                     }
                 }
-                self.getCleanDeformAction();
+                if (self !is null)
+                    self.getCleanDeformAction();
             }
             undoable = false;
         }
@@ -143,7 +144,8 @@ class MeshEditorDeformationAction  : LazyBoundAction {
                         self.applyOffsets(deform.getValue(param.findClosestKeypoint()).vertexOffsets);
                     }
                 }
-                self.getCleanDeformAction();
+                if (self !is null)
+                    self.getCleanDeformAction();
             }
             undoable = true;
         }
@@ -260,11 +262,11 @@ public:
     override
     void redo() {
          if (isApplyable()) {
-            if (newPathPoints !is null && newPathPoints.length > 0) {
+            if (newPathPoints !is null && newPathPoints.length > 0 && path !is null) {
                 this.path.points = newPathPoints.dup;
                 this.path.update();
             }
-            if (newTargetPathPoints !is null && newTargetPathPoints.length > 0) {
+            if (newTargetPathPoints !is null && newTargetPathPoints.length > 0 && path !is null && path.target !is null) {
                 this.path.target.points = newTargetPathPoints.dup;
                 this.path.target.update();
             }

--- a/source/creator/core/actionstack.d
+++ b/source/creator/core/actionstack.d
@@ -62,7 +62,7 @@ void incActionUndo() {
 */
 void incActionRedo() {
     if (actionPointer >= actions.length) {
-        actionPointer = actions.length-1;
+        actionPointer = actions.length;
         return;
     }
     actions[actionPointer].redo();

--- a/source/creator/viewport/common/mesheditor.d
+++ b/source/creator/viewport/common/mesheditor.d
@@ -310,10 +310,10 @@ public:
         if (deformAction is null || !deformAction.isApplyable()) {
             switch (toolMode) {
             case VertexToolMode.Points:
-                deformAction = new MeshEditorDeformationAction("test", this);
+                deformAction = new MeshEditorDeformationAction(target.name);
                 break;
             case VertexToolMode.PathDeform:
-                deformAction = new MeshEditorPathDeformAction("test", this, path);
+                deformAction = new MeshEditorPathDeformAction(target.name);
                 break;
             default:
             }

--- a/source/creator/viewport/model/deform/package.d
+++ b/source/creator/viewport/model/deform/package.d
@@ -73,3 +73,7 @@ void incViewportModelDeformOverlay() {
 void incViewportModelDeformToolSettings() {
 
 }
+
+IncMeshEditor incViewportModelDeformGetEditor() {
+    return editor;
+}


### PR DESCRIPTION
Changes:
- Changed some undo / redo actions not to store all states regarding UI (e.g. MeshEditor, and CatmullSpline) so that garbage collector can collect them appropriately.
- Changed some undo / redo actions not to store both old and new states to improve memory efficiency.
- Fix problems of dealing of actionPointer in actionstack.d regarding the end of undo stack.

Known Issue:
- It seems some PathDeformation undo has some bugs remained in minor condition. I cannot reproduce the situation so far.
  (It might be the result of complex operation of redo and undo.)