### PR TITLE
Adds a note about how to build without branding (barebones config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ To disable branding, you can build the package without the `--config=full` optio
 
 **Without branding**: ``dub build --compiler=ldc2 --build=release``
 
+More information can be found inside of the [`dub.sdl`](https://github.com/Inochi2D/inochi-creator/blob/main/dub.sdl#L26) file
+
 &nbsp;
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ You may request permission to use our branding assets in your package by submitt
 Barebones builds are more or less equivalent to official builds with the exception that branding is removed,  
 and that we don't accept support tickets unless a problem can be replicated on an official build.
 
+To disable branding, you can build the package without the `--config=full` option, like so:
+
+**With branding**:  `dub build --compiler=ldc2 --build=release --config=full`
+
+**Without branding**: ``dub build --compiler=ldc2 --build=release``
+
 &nbsp;
 
 ## Building


### PR DESCRIPTION
Just to be sure that package maintainers know how exactly to use a barebones config