### PR TITLE
Avoid crash caused by MeshEditorPathDeformAction.

### DIFF
--- a/source/creator/actions/mesheditor.d
+++ b/source/creator/actions/mesheditor.d
@@ -201,7 +201,10 @@ public:
     SplinePoint[] newTargetPathPoints;
 
     auto path() {
-        return self.getPath();
+        if (self !is null)
+            return self.getPath();
+        else
+            return null;
     }
 
     this(string name, void delegate() update = null) {
@@ -210,7 +213,7 @@ public:
             oldPathPoints = path.points.dup;
         else
             oldPathPoints = null;
-        if (this.path.target !is null)
+        if (this.path && this.path.target !is null)
             oldTargetPathPoints = this.path.target.points.dup;
         else
             oldTargetPathPoints = null;


### PR DESCRIPTION
MeshEditorPathDeformAction::clear crashed application when incViewportModelDeformGetEditor return null.
This result in application crash when press TAB to switch path deformer mode.
To avoid crash, just ignore and return null if MeshEditor is not returned temporary.
This code still put invalid action into undo stack, but less harmful than to crash.