### PR TITLE
Fix bug #89 and garbage for workaround.

### DIFF
--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -838,8 +838,17 @@ protected:
             foreach(i, ref param; parameters) {
                 if (incArmedParameter() == param) continue;
                 import std.algorithm.searching : canFind;
-                if (filter.length == 0 || param.indexableName.canFind(filter)) {
-                    if (ExParameterGroup group = cast(ExParameterGroup)param) {
+                ExParameterGroup group = cast(ExParameterGroup)param;
+                bool found = filter.length == 0 || param.indexableName.canFind(filter);
+                if (group) {
+                    foreach (ix, ref child; group.children) {
+                        if (incArmedParameter() == child) continue;
+                        if (child.indexableName.canFind(filter))
+                            found = true;
+                    }
+                }
+                if (found) {
+                    if (group) {
                         igPushID(group.uuid);
 
                             bool open;
@@ -920,9 +929,10 @@ protected:
 
                                     // Skip armed param
                                     if (incArmedParameter() == child) continue;
-
-                                    // Otherwise render it
-                                    incParameterView(ix, child, &grabParam, false, group.children, group.color);
+                                    if (child.indexableName.canFind(filter)) {
+                                        // Otherwise render it
+                                        incParameterView(ix, child, &grabParam, false, group.children, group.color);
+                                    }
                                 }
                             }
                             incEndCategory();

--- a/source/creator/widgets/inputtext.d
+++ b/source/creator/widgets/inputtext.d
@@ -11,7 +11,6 @@ import inochi2d;
 import bindbc.sdl;
 import std.stdio;
 import std.string;
-import std.utf;
 import core.memory : GC;
 
 private {

--- a/source/creator/widgets/inputtext.d
+++ b/source/creator/widgets/inputtext.d
@@ -10,6 +10,8 @@ import creator.core;
 import inochi2d;
 import bindbc.sdl;
 import std.stdio;
+import std.string;
+import std.utf;
 import core.memory : GC;
 
 private {
@@ -35,6 +37,12 @@ bool incInputText(string wId, float width, ref string buffer, ImGuiInputTextFlag
     // NOTE: null strings would result in segfault, make sure it's at least just empty.
     if (buffer.ptr is null) {
         buffer = "";
+    }
+
+    if (buffer.ptr[buffer.length] != '\0') {
+        // If buffer.ptr does not end with '\0', recreate string to force '\0' at the end.
+        string buffer2 = buffer;
+        buffer = fromStringz(buffer2.ptr[0..buffer2.length]~'\0');
     }
 
     // Push ID


### PR DESCRIPTION
When garbage is added at the end of string, sometimes deletion of the character makes invalid UTF-8 string, and that result in application crash.
To avoid that, recreating string so that ensure that character ends with '\0'
This assumes that provided string for incInputText has at least buffer.length + 1 bytes, may have unpredictable side effect. 
(This is also assumed in the existing codes,  too.)
This code recreate string only if that does not end with '\0', and this code is rarely executed. So this affect nothing for performance.