### PR TITLE
Sort languages

### DIFF
--- a/source/creator/core/i18n.d
+++ b/source/creator/core/i18n.d
@@ -6,6 +6,7 @@ import i18n.tr;
 import std.file;
 import std.path;
 import std.string;
+import std.algorithm : sort;
 
 /+
     HACK: This little comment tricks genpot to generate our LANG_NAME entry.
@@ -42,7 +43,6 @@ private {
 
         // Skip non-existent paths
         if (!path.exists) return;
-
         foreach(DirEntry entry; dirEntries(path, "*.mo", SpanMode.shallow)) {
             
             // Get langcode from filename
@@ -53,7 +53,7 @@ private {
 
             string langName = i18nGetLanguageName(entry.name);
             if (langName == "<UNKNOWN LANGUAGE>") langName = incGetCultureExpression(langcode);
-
+            
             // Add locale
             localeFiles ~= TLEntry(
                 langName,
@@ -96,6 +96,9 @@ void incLocaleInit() {
     // this is here to detect it and add it in to the scan area.
     auto extraLocalePath = incGetAppLocalePathExtra();
     if (extraLocalePath) incLocaleScan(extraLocalePath);
+    
+    // sort the files by human readable name
+    localeFiles.sort!((a,b) => a.humanName < b.humanName);
 }
 
 /**

--- a/source/creator/core/i18n.d
+++ b/source/creator/core/i18n.d
@@ -7,6 +7,7 @@ import std.file;
 import std.path;
 import std.string;
 import std.algorithm : sort;
+import std.uni : icmp;
 
 /+
     HACK: This little comment tricks genpot to generate our LANG_NAME entry.
@@ -100,12 +101,18 @@ void incLocaleInit() {
     if (extraLocalePath) incLocaleScan(extraLocalePath);
     
     // sort the files by human readable name
-    localeFiles.sort!((a,b) => (a.humanName == b.humanName) ? (a.path < b.path) 
-                                                            : (a.humanName < b.humanName));
+    localeFiles.sort!(compareEntries);
     //disambiguate locales with the same human name
     markDups(localeFiles);
 }
 
+bool compareEntries(TLEntry a, TLEntry b) {
+    int cmp = icmp(a.humanName, b.humanName);
+    if (cmp == 0) {
+        return a.path < b.path;
+    }
+    return cmp < 0;
+}
 
 /**
     Disambiguate by source folder for TLEntrys with identical humanNames.


### PR DESCRIPTION
Sorts language alphabetically (by unicode). This should result in a mostly sensible order with similar scripts lumped together. (#71)

Also implements disambiguation of locales with identical names by specifying the source folder. This can be a pretty long path name sometimes, but should be alright. Could do some string processing on the paths to shorten while keeping equal expressivity.
![](https://media.discordapp.net/attachments/855173611409506337/1026595024265289830/unknown.png)

cwd no longer searched for locale files.
