### PR TITLE
Clean up macOS CI uninstall list

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -180,17 +180,7 @@ jobs:
         brew install create-dmg gettext
 
         # Remove conflicting brew items
-        brew remove --ignore-dependencies aom cairo composer curl fontconfig freetype gd ghostscript httpd imagemagick jpeg-xl libavif libheif libxft mongodb-community@5.0 mongosh node@16 openjpeg php r sox webp libpng brotli
-
-        # Delete fake harfbuzz if need be
-        if [ -f "/usr/local/lib/libharfbuzz.dylib" ]; then
-          sudo rm -r /usr/local/lib/libharfbuzz.dylib
-        fi
-
-        # And the .a for it as well
-        if [ -f "/usr/local/lib/libharfbuzz.a" ]; then
-          sudo rm -r /usr/local/lib/libharfbuzz.a
-        fi
+        brew remove --ignore-dependencies freetype harfbuzz libpng brotli
 
     - name: 'Generate i18n'
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -180,7 +180,10 @@ jobs:
         brew install create-dmg gettext
 
         # Remove conflicting brew items
-        brew remove --ignore-dependencies freetype harfbuzz libpng brotli
+        # GitHub Actions likes to randomly change what packages are installed, so assume that if any of these fail, it was never installed and won't cause any problems
+        for package in freetype harfbuzz libpng brotli; do
+          brew remove --ignore-dependencies "$package" || true
+        done
 
     - name: 'Generate i18n'
       run: |


### PR DESCRIPTION
Just makes the list of packages to remove a little cleaner looking

Using brew to uninstall harfbuzz worked fine, and most of the packages didn't seem to be getting referenced by anything.  It seems to still build, and runs fine on x86, but I don't have an arm Mac to test that.

~~Also adds a space to the `CFBundleName` entry in the `Info.plist`, which is what shows up in the menubar when the application is running.  You'd think macOS would use the `CFBundleDisplayName` for that but it doesn't.~~ Moved to #103