### PR TITLE
Fix `CFBundleName` in macOS Info.plist

### DIFF
--- a/res/Info.plist
+++ b/res/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>CFBundleName</key>
-    <string>InochiCreator</string>
+    <string>Inochi Creator</string>
     <key>CFBundleDisplayName</key>
     <string>Inochi Creator</string>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
Adds a space to match with the rest of the names.
CFBundleName is used by macOS to decide what to put in the menubar for the main application menu.  You'd think it would use the `CFBundleDisplayName` for that but it doesn't