### PR TITLE
Hide tracking on release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
     - name: 'Build Inochi Creator'
       run: |
         # Build the project, with its main file included, without unittests
-        dub build --compiler=ldc2 --build=release --config=full
+        dub build --compiler=ldc2 --build=release --config=full --debug=tracking
 
     - name: 'Build AppImage'
       run: |
@@ -148,7 +148,7 @@ jobs:
               }
           }
           Invoke-VSDevEnvironment
-          dub build --compiler=ldc2 --build=release --config=win32-full
+          dub build --compiler=ldc2 --build=release --config=win32-full --debug=tracking
 
     - name: Archive Zip
       uses: thedoctor0/zip-release@main
@@ -212,12 +212,12 @@ jobs:
       run: |
         # First build ARM64 version...
         echo "Building arm64 binary..."
-        dub build --build=release --config=osx-full --arch=arm64-apple-macos
+        dub build --build=release --config=osx-full --arch=arm64-apple-macos --debug=tracking
         mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-arm64"
 
         # Then the X86_64 version...
         echo "Building x86_64 binary..."
-        dub build --build=release --config=osx-full --arch=x86_64-apple-macos
+        dub build --build=release --config=osx-full --arch=x86_64-apple-macos --debug=tracking
         mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-x86_64"
 
         # Glue them together with lipo

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
     - name: 'Build Inochi Creator'
       run: |
         # Build the project, with its main file included, without unittests
-        dub build --compiler=ldc2 --build=release --config=full --debug=tracking
+        dub build --compiler=ldc2 --build=release --config=full --debug=InExperimental
 
     - name: 'Build AppImage'
       run: |
@@ -148,7 +148,7 @@ jobs:
               }
           }
           Invoke-VSDevEnvironment
-          dub build --compiler=ldc2 --build=release --config=win32-full --debug=tracking
+          dub build --compiler=ldc2 --build=release --config=win32-full --debug=InExperimental
 
     - name: Archive Zip
       uses: thedoctor0/zip-release@main
@@ -212,12 +212,12 @@ jobs:
       run: |
         # First build ARM64 version...
         echo "Building arm64 binary..."
-        dub build --build=release --config=osx-full --arch=arm64-apple-macos --debug=tracking
+        dub build --build=release --config=osx-full --arch=arm64-apple-macos --debug=InExperimental
         mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-arm64"
 
         # Then the X86_64 version...
         echo "Building x86_64 binary..."
-        dub build --build=release --config=osx-full --arch=x86_64-apple-macos --debug=tracking
+        dub build --build=release --config=osx-full --arch=x86_64-apple-macos --debug=InExperimental
         mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-x86_64"
 
         # Glue them together with lipo

--- a/source/creator/core/package.d
+++ b/source/creator/core/package.d
@@ -603,7 +603,7 @@ void incSetDefaultLayout() {
     igDockBuilderDockWindow("###Tool Settings", dockIDToolSettings);
     igDockBuilderDockWindow("###History", dockIDHistory);
     igDockBuilderDockWindow("###Scene", dockIDHistory);
-    debug(tracking) igDockBuilderDockWindow("###Tracking", dockIDHistory);
+    debug(InExperimental) igDockBuilderDockWindow("###Tracking", dockIDHistory);
     igDockBuilderDockWindow("###Timeline", dockIDTimeline);
     igDockBuilderDockWindow("###Logger", dockIDTimeline);
     igDockBuilderDockWindow("###Parameters", dockIDParams);

--- a/source/creator/core/package.d
+++ b/source/creator/core/package.d
@@ -603,7 +603,7 @@ void incSetDefaultLayout() {
     igDockBuilderDockWindow("###Tool Settings", dockIDToolSettings);
     igDockBuilderDockWindow("###History", dockIDHistory);
     igDockBuilderDockWindow("###Scene", dockIDHistory);
-    igDockBuilderDockWindow("###Tracking", dockIDHistory);
+    debug(tracking) igDockBuilderDockWindow("###Tracking", dockIDHistory);
     igDockBuilderDockWindow("###Timeline", dockIDTimeline);
     igDockBuilderDockWindow("###Logger", dockIDTimeline);
     igDockBuilderDockWindow("###Parameters", dockIDParams);

--- a/source/creator/panels/tracking.d
+++ b/source/creator/panels/tracking.d
@@ -51,6 +51,7 @@ private:
 
 protected:
     override
+    debug(tracking)
     void onUpdate() {
 
         if (incEditMode == EditMode.ModelTest) {
@@ -157,6 +158,6 @@ public:
 /**
     Generate tracking panel frame
 */
-mixin incPanel!TrackingPanel;
+debug(tracking) mixin incPanel!TrackingPanel;
 
 

--- a/source/creator/panels/tracking.d
+++ b/source/creator/panels/tracking.d
@@ -51,7 +51,7 @@ private:
 
 protected:
     override
-    debug(tracking)
+    debug(InExperimental)
     void onUpdate() {
 
         if (incEditMode == EditMode.ModelTest) {
@@ -158,6 +158,6 @@ public:
 /**
     Generate tracking panel frame
 */
-debug(tracking) mixin incPanel!TrackingPanel;
+debug(InExperimental) mixin incPanel!TrackingPanel;
 
 

--- a/source/creator/widgets/toolbar.d
+++ b/source/creator/widgets/toolbar.d
@@ -57,7 +57,7 @@ void incToolbar() {
                 // Render mode switch buttons
                 ImVec2 avail;
                 igGetContentRegionAvail(&avail);
-                debug(tracking) igDummy(ImVec2(avail.x-(32*3), 0));
+                debug(InExperimental) igDummy(ImVec2(avail.x-(32*3), 0));
                 else igDummy(ImVec2(avail.x-(32*2), 0));
                 igPushStyleVar(ImGuiStyleVar.FramePadding, ImVec2(0, 0));
                 igPushStyleVar(ImGuiStyleVar.FrameRounding, 0);
@@ -72,7 +72,7 @@ void incToolbar() {
                                 incSetEditMode(EditMode.AnimEdit);
                             }
                             incTooltip(_("Edit Animation"));
-                            debug(tracking) {
+                            debug(InExperimental) {
                                 if (incButtonColored("", ImVec2(32, 32), incEditMode == EditMode.ModelTest ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
                                     incSetEditMode(EditMode.ModelTest);
                                 }

--- a/source/creator/widgets/toolbar.d
+++ b/source/creator/widgets/toolbar.d
@@ -57,8 +57,8 @@ void incToolbar() {
                 // Render mode switch buttons
                 ImVec2 avail;
                 igGetContentRegionAvail(&avail);
-                igDummy(ImVec2(avail.x-(32*3), 0));
-
+                debug(tracking) igDummy(ImVec2(avail.x-(32*3), 0));
+                else igDummy(ImVec2(avail.x-(32*2), 0));
                 igPushStyleVar(ImGuiStyleVar.FramePadding, ImVec2(0, 0));
                 igPushStyleVar(ImGuiStyleVar.FrameRounding, 0);
                     igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0));
@@ -72,11 +72,12 @@ void incToolbar() {
                                 incSetEditMode(EditMode.AnimEdit);
                             }
                             incTooltip(_("Edit Animation"));
-
-                            if (incButtonColored("", ImVec2(32, 32), incEditMode == EditMode.ModelTest ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
-                                incSetEditMode(EditMode.ModelTest);
+                            debug(tracking) {
+                                if (incButtonColored("", ImVec2(32, 32), incEditMode == EditMode.ModelTest ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
+                                    incSetEditMode(EditMode.ModelTest);
+                                }
+                                incTooltip(_("Test Puppet"));
                             }
-                            incTooltip(_("Test Puppet"));
                         }
                     igPopStyleVar();
                 igPopStyleVar(2);


### PR DESCRIPTION
I have to say that I really like the current state of inochi-creator, but I feel that the "Test Puppet" function pales in comparison to all the polish the app has received during the last months :)

Since there is no much time for the 0.7.4 release, I wanted to propose to hide that feature, which would imply to hide the "Test Puppet" button and the "Tracking panel". I'm proposing this mostly because currently inochi-session is in a state that can fill the role of this feature.

This implementation hides the buttons and panels behind a debug variable, which is activated on nightly releases.