### PR TITLE
on-screen-edit: Show operation handles only when edit mode is ModelEdit.

### DIFF
--- a/source/creator/panels/viewport.d
+++ b/source/creator/panels/viewport.d
@@ -173,7 +173,8 @@ protected:
                 incBeginViewportToolArea("ConfirmArea", ImGuiDir.Left, ImGuiDir.Down, false);
                     incViewportDrawConfirmBar();
                 incEndViewportToolArea();
-                incViewportTransformHandle();
+                if (incEditMode == EditMode.ModelEdit)
+                    incViewportTransformHandle();
             igPopStyleVar();
 
             lastSize = currSize;

--- a/source/creator/viewport/package.d
+++ b/source/creator/viewport/package.d
@@ -458,6 +458,11 @@ void incViewportTransformHandle() {
                             } else {
                                 status.lockOrientation(LockedOrientation.Horizontal);
                             }
+                            if (status.locked == LockedOrientation.Vertical) {
+                                newValueY = prevValue.y;
+                            } else if (status.locked == LockedOrientation.Horizontal) {
+                                newValueX = prevValue.x;
+                            }
                         }
                     } else {
                         status.lockOrientation(LockedOrientation.None);
@@ -469,12 +474,6 @@ void incViewportTransformHandle() {
                         newValueY = floor(newValueY * 10) / 10;
                     }
                     
-                    if (status.locked == LockedOrientation.Vertical) {
-                        newValueY = prevValue.y;
-                    } else if (status.locked == LockedOrientation.Horizontal) {
-                        newValueX = prevValue.x;
-                    }
-
                     if (armedParam) {
                         changeParameter(selectedNode, armedParam, "transform.s.x", index, newValueX);
                         changeParameter(selectedNode, armedParam, "transform.s.y", index, newValueY);


### PR DESCRIPTION
Translation / scaling / ration handle is required only for Model Edit.
In vertex edit mode, this handle should not be displayed.
This patch suppress handles other than ModelEdit mode.