### PR TITLE
Replace spawnShell() with browse()

### DIFF
--- a/source/creator/utils/link.d
+++ b/source/creator/utils/link.d
@@ -12,10 +12,10 @@ import std.process;
 */
 void incOpenLink(string link) {
     version(Windows) {
-        spawnShell("start " ~ escapeShellCommand("", link));
+        browse(link);
     } else version(OSX) {
-        spawnShell("open " ~ escapeShellCommand(link));
+        browse(link);
     } else version(Posix) {
-        spawnShell("xdg-open " ~ escapeShellCommand(link));
+        browse(link);
     }
 }


### PR DESCRIPTION
Console window no longer appears when opening a URL on Windows.