### PR TITLE
Fixed bug #174

### DIFF
--- a/source/creator/viewport/model/package.d
+++ b/source/creator/viewport/model/package.d
@@ -137,7 +137,7 @@ void incViewportModelConfirmBar() {
                         incSelectNode(node);
                         incVertexEditSetTarget(node);
                         incFocusCamera(node, vec2(0, 0));
-                        incVertexEditCopyMeshDataToTarget(payloadDrawable, payloadDrawable.getMesh());
+                        incVertexEditCopyMeshDataToTarget(node, payloadDrawable, payloadDrawable.getMesh());
                     }
                 }
                 igEndDragDropTarget();

--- a/source/creator/viewport/vertex/package.d
+++ b/source/creator/viewport/vertex/package.d
@@ -238,9 +238,13 @@ void incVertexEditSetTarget(Drawable target) {
     editor.setTarget(target);
 }
 
-void incVertexEditCopyMeshDataToTarget(Drawable drawable, MeshData data) {
-    if (editor.getEditorFor(drawable)) {
-        editor.getEditorFor(drawable).importMesh(data);
+void incVertexEditCopyMeshDataToTarget(Drawable target, Drawable drawable, MeshData data) {
+    if (editor.getEditorFor(target)) {
+        editor.getEditorFor(target).importMesh(data);
+    } else {
+        editor.addTarget(target);
+        assert(editor.getEditorFor(target));
+        editor.getEditorFor(target).importMesh(data);
     }
 }
 


### PR DESCRIPTION
Multi-edit patch requires target drawable to be added to IncMeshEditor by calling addTarget method.
This is not handled correctly for the "Copy Mesh" operation.
I fixed above problem by explicitly calling addTarget in that operation.