### PR TITLE
Fix bug #143.

### DIFF
--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -69,7 +69,6 @@ private:
         // Iterate over flat mesh and extract it in to
         // vertices and "connections"
         MeshVertex*[] iVertices;
-
         iVertices.length = data.vertices.length;
         foreach(idx, vertex; data.vertices) {
             iVertices[idx] = new MeshVertex(vertex, []);

--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -224,7 +224,7 @@ public:
     abstract void setTarget(Node target);
     abstract void resetMesh();
     abstract void refreshMesh();
-    abstract void importMesh(MeshData data);
+    abstract void importMesh(ref MeshData data);
     abstract void applyOffsets(vec2[] offsets);
     abstract vec2[] getOffsets();
 

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -77,7 +77,7 @@ public:
     }
 
     override
-    void importMesh(MeshData data) {
+    void importMesh(ref MeshData data) {
         mesh.import_(data);
         mesh.refresh();
     }

--- a/source/creator/viewport/common/mesheditor/operations/node.d
+++ b/source/creator/viewport/common/mesheditor/operations/node.d
@@ -63,7 +63,7 @@ public:
         translation = vec2(target.getValue("transform.t.x"), target.getValue("transform.t.y"));
     }
 
-    override void importMesh(MeshData data) {}
+    override void importMesh(ref MeshData data) {}
 
     override
     void applyOffsets(vec2[] offsets) {

--- a/source/creator/viewport/vertex/package.d
+++ b/source/creator/viewport/vertex/package.d
@@ -238,7 +238,7 @@ void incVertexEditSetTarget(Drawable target) {
     editor.setTarget(target);
 }
 
-void incVertexEditCopyMeshDataToTarget(Drawable target, Drawable drawable, MeshData data) {
+void incVertexEditCopyMeshDataToTarget(Drawable target, Drawable drawable, ref MeshData data) {
     if (editor.getEditorFor(target)) {
         editor.getEditorFor(target).importMesh(data);
     } else {


### PR DESCRIPTION
IncMesh.importMesh is assumed that reference to MeshData is passed, but current implementation passes temporary variable for it.
This is a workaround patch to pass the reference to the MeshData to IncMesh.importMesh.
This patch may have hidden side effect, because mesh data of different Drawable is passed in some cases.
("Copy Mesh" operation passes the MeshData of payloadDrawable.)
Currently this patch seems to work, but need to consider whether passing reference to MeshData is desired or not.