### PR TITLE
Two enhancement for the path deformation tool.

### DIFF
--- a/source/creator/viewport/common/mesheditor/operations/impl.d
+++ b/source/creator/viewport/common/mesheditor/operations/impl.d
@@ -54,7 +54,7 @@ public:
     override
     void setPath(CatmullSpline path) {
         auto pathTool = cast(PathDeformTool)(tools[VertexToolMode.PathDeform]);
-        pathTool.path = path;
+        pathTool.setPath(path);
     }
 
     override int peek(ImGuiIO* io, Camera camera) {

--- a/source/creator/viewport/common/mesheditor/operations/node.d
+++ b/source/creator/viewport/common/mesheditor/operations/node.d
@@ -196,7 +196,6 @@ public:
                 }
             }
             if (dirty) {
-                writefln("pushDeformAction: %s", target.name);
                 editorAction.updateNewState();
                 foreach (a; editorAction.action.actions) {
                     if (auto laction = cast(LazyBoundAction)a)

--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -131,8 +131,8 @@ class PathDeformTool : NodeSelect {
                         editPath.points[i].position = (rotate * vec4(editPath.points[i].position, 0, 1)).xy;
                     }
                 } else if (io.KeyShift) {
-                    float off = editPath.findClosestPointOffset(impl.mousePos);
-                    vec2 pos  = editPath.eval(off);
+                    float off = path.findClosestPointOffset(impl.mousePos);
+                    vec2 pos  = path.eval(off);
                     editPath.points[pathDragTarget].position = pos;
                 } else {
                     vec2 relTranslation = impl.mousePos - impl.lastMousePos;

--- a/source/creator/viewport/common/spline.d
+++ b/source/creator/viewport/common/spline.d
@@ -441,7 +441,7 @@ public:
         interpolate();
     }
 
-    void draw(mat4 trans, vec4 color) {
+    void draw(mat4 trans, vec4 color, uint lockedPoint = -1) {
         if (drawLines.length > 0) {
             inDbgSetBuffer(drawLines);
             inDbgDrawLines(color, trans);
@@ -452,6 +452,11 @@ public:
             inDbgDrawPoints(vec4(0, 0, 0, 1), trans);
             inDbgPointsSize(6);
             inDbgDrawPoints(color, trans);
+        }
+        if (lockedPoint >= 0 && lockedPoint < drawPoints.length) {
+            inDbgSetBuffer([drawPoints[lockedPoint]]);
+            inDbgPointsSize(6);
+            inDbgDrawPoints(vec4(1, 0, 0, 1), trans);
         }
     }
 


### PR DESCRIPTION
Added two experimental enhancement to path deformation tool.

1st modification is "Locked point", which lock the control point of path tool, and allows only rotation around locked point.
Look at demo video.  path deformation tool is locked at hip of Midori. and other control points just rotated around locked point.

2nd modification is "lock control points onto outline of the path."
In this mode, control point can only move along the path. This enables easy transformation when looking aside etc.
In demo video, control points are locked along the path. so rigger can transform the face angle easily.