### PR TITLE
Auto-flipping

### DIFF
--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -425,7 +425,10 @@ private {
             if (igMenuItem(__("Set from mirror"), "", false, true)) {
                 auto action = new ParameterChangeBindingsValueAction("set From Mirror", param, bindings, cParamPoint.x, cParamPoint.y);
                 foreach(binding; bindings) {
-                    binding.extrapolateValueAt(cParamPoint, 0);
+                    Node target = binding.getTarget().node;
+                    auto pair = incGetFlipPairFor(target);
+                    auto srcBinding = getPairBindingFor(param, target, pair, binding.getName());
+                    autoFlipBinding(binding, srcBinding, cParamPoint, 0);
                 }
                 action.updateNewState();
                 incActionPush(action);

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -137,32 +137,32 @@ private {
         }
     }
 
+    ParameterBinding getPairBindingFor(Parameter param, Node target, FlipPair pair, string name) {
+        Node pairNode;
+        if (pair is null)
+            return null;
+        if (pair.parts[0].uuid == target.uuid) {
+            pairNode = pair.parts[1];
+        } else {
+            pairNode = pair.parts[0];
+        }
+        if (pairNode is null)
+            return null;
+        foreach (ParameterBinding binding; param.bindings) {
+            if (binding.getTarget().node.uuid == pairNode.uuid && binding.getName() == name)
+                return binding;
+        }
+        return null;
+    }
+
     void mirroredAutofill(Parameter param, uint axis, float min, float max) {
         auto action = new ParameterChangeBindingsAction("Mirror Auto Fill", param, null);
-
-        ParameterBinding getPairBindingFor(Node target, FlipPair pair, string name) {
-            Node pairNode;
-            if (pair is null)
-                return null;
-            if (pair.parts[0].uuid == target.uuid) {
-                pairNode = pair.parts[1];
-            } else {
-                pairNode = pair.parts[0];
-            }
-            if (pairNode is null)
-                return null;
-            foreach (ParameterBinding binding; param.bindings) {
-                if (binding.getTarget().node.uuid == pairNode.uuid && binding.getName() == name)
-                    return binding;
-            }
-            return null;
-        }
 
         foreach(ParameterBinding binding; param.bindings) {
 
             Node target = binding.getTarget().node;
             auto pair = incGetFlipPairFor(target);
-            auto srcBinding = getPairBindingFor(target, pair, binding.getName());
+            auto srcBinding = getPairBindingFor(param, target, pair, binding.getName());
 
             uint xCount = param.axisPointCount(0);
             uint yCount = param.axisPointCount(1);
@@ -174,7 +174,6 @@ private {
                     if (axis == 1 && (offY < min || offY > max)) continue;
 
                     vec2u index = vec2u(x, y);
-
                     if (!binding.isSet(index)) autoFlipBinding(binding, srcBinding, index, axis);
                 }
             }
@@ -387,7 +386,10 @@ private {
                 if (igMenuItem(__("Horizontally"), "", false, true)) {
                     auto action = new ParameterChangeBindingsValueAction("set From Mirror (Horizontally)", param, bindings, cParamPoint.x, cParamPoint.y);
                     foreach(binding; bindings) {
-                        binding.extrapolateValueAt(cParamPoint, 0);
+                        Node target = binding.getTarget().node;
+                        auto pair = incGetFlipPairFor(target);
+                        auto srcBinding = getPairBindingFor(param, target, pair, binding.getName());
+                        autoFlipBinding(binding, srcBinding, cParamPoint, 0);
                     }
                     action.updateNewState();
                     incActionPush(action);
@@ -396,7 +398,10 @@ private {
                 if (igMenuItem(__("Vertically"), "", false, true)) {
                     auto action = new ParameterChangeBindingsValueAction("set From Mirror (Vertically)", param, bindings, cParamPoint.x, cParamPoint.y);
                     foreach(binding; bindings) {
-                        binding.extrapolateValueAt(cParamPoint, 1);
+                        Node target = binding.getTarget().node;
+                        auto pair = incGetFlipPairFor(target);
+                        auto srcBinding = getPairBindingFor(param, target, pair, binding.getName());
+                        autoFlipBinding(binding, srcBinding, cParamPoint, 1);
                     }
                     action.updateNewState();
                     incActionPush(action);
@@ -405,7 +410,10 @@ private {
                 if (igMenuItem(__("Diagonally"), "", false, true)) {
                     auto action = new ParameterChangeBindingsValueAction("set From Mirror (Diagonally)", param, bindings, cParamPoint.x, cParamPoint.y);
                     foreach(binding; bindings) {
-                        binding.extrapolateValueAt(cParamPoint, -1);
+                        Node target = binding.getTarget().node;
+                        auto pair = incGetFlipPairFor(target);
+                        auto srcBinding = getPairBindingFor(param, target, pair, binding.getName());
+                        autoFlipBinding(binding, srcBinding, cParamPoint, -1);
                     }
                     action.updateNewState();
                     incActionPush(action);

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -14,6 +14,8 @@ import creator.core;
 import creator.actions;
 import creator.ext.param;
 import creator.viewport.common.mesheditor;
+import creator.viewport.common.mesh;
+import creator.windows.flipconfig;
 import creator;
 import std.string;
 import inochi2d;
@@ -81,9 +83,87 @@ private {
         incActionPush(action);
     }
 
+    void autoFlipBinding(ParameterBinding binding, ParameterBinding srcBinding, vec2u index, uint axis) {
+
+        T extrapolateValueAt(T)(ParameterBindingImpl!T binding, vec2u index, uint axis) {
+            vec2 offset = binding.parameter.getKeypointOffset(index);
+
+            switch (axis) {
+                case -1: offset = vec2(1, 1) - offset; break;
+                case 0: offset.x = 1 - offset.x; break;
+                case 1: offset.y = 1 - offset.y; break;
+                default: assert(false, "bad axis");
+            }
+
+            vec2u srcIndex;
+            vec2 subOffset;
+            binding.parameter.findOffset(offset, srcIndex, subOffset);
+
+            return binding.interpolate(srcIndex, subOffset);            
+        }
+
+        auto deformBinding = cast(DeformationParameterBinding)binding;
+        if (srcBinding !is null) {
+            if (deformBinding !is null) {
+                Drawable drawable = cast(Drawable)deformBinding.getTarget().node;
+                auto srcDeformBinding = cast(DeformationParameterBinding)srcBinding;
+                Drawable srcDrawable = cast(Drawable)srcDeformBinding.getTarget().node;
+                auto mesh = new IncMesh(drawable.getMesh());
+                auto deform = extrapolateValueAt!Deformation(srcDeformBinding, index, axis);
+                auto newDeform = mesh.deformByDeformationBinding(srcDrawable, deform, true);
+                if (newDeform)
+                    deformBinding.setValue(index, *newDeform);
+
+            } else {
+                auto srcValueBinding = cast(ValueParameterBinding)srcBinding;
+                auto value = extrapolateValueAt!float(srcValueBinding, index, axis);
+
+                auto valueBinding = cast(ValueParameterBinding)binding;
+                valueBinding.setValue(index, value);
+                valueBinding.scaleValueAt(index, axis, -1);
+            }
+
+        } else {
+            if (deformBinding !is null) {
+                Drawable drawable = cast(Drawable)deformBinding.getTarget().node;
+                auto mesh = new IncMesh(drawable.getMesh());
+                Deformation deform = extrapolateValueAt!Deformation(deformBinding, index, axis);
+                auto newDeform = mesh.deformByDeformationBinding(drawable, deform, true);
+                if (newDeform)
+                    deformBinding.setValue(index, *newDeform);
+            } else {
+                binding.extrapolateValueAt(index, axis);
+            }
+        }
+    }
+
     void mirroredAutofill(Parameter param, uint axis, float min, float max) {
         auto action = new ParameterChangeBindingsAction("Mirror Auto Fill", param, null);
+
+        ParameterBinding getPairBindingFor(Node target, FlipPair pair, string name) {
+            Node pairNode;
+            if (pair is null)
+                return null;
+            if (pair.parts[0].uuid == target.uuid) {
+                pairNode = pair.parts[1];
+            } else {
+                pairNode = pair.parts[0];
+            }
+            if (pairNode is null)
+                return null;
+            foreach (ParameterBinding binding; param.bindings) {
+                if (binding.getTarget().node.uuid == pairNode.uuid && binding.getName() == name)
+                    return binding;
+            }
+            return null;
+        }
+
         foreach(ParameterBinding binding; param.bindings) {
+
+            Node target = binding.getTarget().node;
+            auto pair = incGetFlipPairFor(target);
+            auto srcBinding = getPairBindingFor(target, pair, binding.getName());
+
             uint xCount = param.axisPointCount(0);
             uint yCount = param.axisPointCount(1);
             foreach(x; 0..xCount) {
@@ -94,7 +174,8 @@ private {
                     if (axis == 1 && (offY < min || offY > max)) continue;
 
                     vec2u index = vec2u(x, y);
-                    if (!binding.isSet(index)) binding.extrapolateValueAt(index, axis);
+
+                    if (!binding.isSet(index)) autoFlipBinding(binding, srcBinding, index, axis);
                 }
             }
         }
@@ -104,7 +185,7 @@ private {
 
     void fixScales(Parameter param) {
         auto action = new ParameterChangeBindingsAction("Fix Scale", param, null);
-        foreach(ParameterBinding binding; param.bindings) {
+        foreach(ParameterBinding binding; param.bindings) {                        
             switch(binding.getName()) {
                 case "transform.s.x":
                 case "transform.s.y":

--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -904,33 +904,32 @@ public:
         }
         // Calculate offset of point in coordinates of triangle.
         vec2 calcOffsetInTriangleCoords(vec2 pt, ref MeshData bindingMesh, ref int[] triangle) {
-            if( (pt - bindingMesh.vertices[triangle[0]]).lengthSquared > (pt - bindingMesh.vertices[triangle[1]]).lengthSquared) {
-                swap(triangle[0], triangle[1]);
-            }
-            if( (pt - bindingMesh.vertices[triangle[0]]).lengthSquared > (pt - bindingMesh.vertices[triangle[2]]).lengthSquared) {
-                swap(triangle[0], triangle[2]);
-            }
             auto p1 = bindingMesh.vertices[triangle[0]];
             if (pt == p1)
                 return vec2(0, 0);
             auto p2 = bindingMesh.vertices[triangle[1]];
             auto p3 = bindingMesh.vertices[triangle[2]];
             vec2 axis0 = p2 - p1;
+            float axis0len = axis0.length;
             axis0 /= axis0.length;
             vec2 axis1 = p3 - p1;
+            float axis1len = axis1.length;
             axis1 /= axis1.length;
             vec3 raxis1 = mat3([axis0.x, axis0.y, 0, -axis0.y, axis0.x, 0, 0, 0, 1]) * vec3(axis1, 1);
             float cosA = raxis1.x;
             float sinA = raxis1.y;
-            mat3 H = mat3([1, -cosA/sinA, 0, 
-                            0, 1/sinA, 0, 
-                            0, 0, 1]) * 
-                     mat3([axis0.x, axis0.y, 0, 
-                            -axis0.y, axis0.x, 0, 
-                            0, 0, 1]) * 
+            mat3 H = mat3([axis0len > 0? 1/axis0len: 0,                           0, 0,
+                           0,                           axis1len > 0? 1/axis1len: 0, 0,
+                           0,                                                     0, 1]) * 
+                     mat3([1, -cosA/sinA, 0, 
+                           0,     1/sinA, 0, 
+                           0,          0, 1]) * 
+                     mat3([ axis0.x, axis0.y, 0, 
+                           -axis0.y, axis0.x, 0, 
+                                  0,       0, 1]) * 
                      mat3([1, 0, -(p1).x, 
-                            0, 1, -(p1).y, 
-                            0, 0, 1]);
+                           0, 1, -(p1).y, 
+                           0, 0,       1]);
             return (H * vec3(pt.x, pt.y, 1)).xy;
         }
 
@@ -950,9 +949,7 @@ public:
             auto p2 = vertices[triangle[1]];
             auto p3 = vertices[triangle[2]];
             vec2 axis0 = p2 - p1;
-            axis0 /= axis0.length;
             vec2 axis1 = p3 - p1;
-            axis1 /= axis1.length;
             return p1 + axis0 * offset.x + axis1 * offset.y;
         }
 

--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -839,7 +839,11 @@ public:
             writeln("part is null");
             return null;
         }
+        Deformation deform = binding.getValue(index);
+        return deformByDeformationBinding(part, deform, flipHorz);
+    }
 
+    Deformation* deformByDeformationBinding(Drawable part, Deformation deform, bool flipHorz = false) {
         auto origVertices = vertices.dup;
 
         // find triangle which covers specified point. 
@@ -994,7 +998,6 @@ public:
         }
         
         MeshData bindingMesh = part.getMesh();
-        Deformation deform = binding.getValue(index);
         Deformation* newDeform = new Deformation([]);
 
         auto targetMesh = transformMesh(bindingMesh, deform);

--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -911,55 +911,27 @@ public:
                 swap(triangle[0], triangle[2]);
             }
             auto p1 = bindingMesh.vertices[triangle[0]];
+            if (pt == p1)
+                return vec2(0, 0);
             auto p2 = bindingMesh.vertices[triangle[1]];
             auto p3 = bindingMesh.vertices[triangle[2]];
             vec2 axis0 = p2 - p1;
-            float axis0len = axis0.length;
             axis0 /= axis0.length;
             vec2 axis1 = p3 - p1;
-            float axis1len = axis1.length;
             axis1 /= axis1.length;
-
-            auto relPt = pt - p1;
-            if (relPt.lengthSquared == 0)
-                return vec2(0, 0);
-            float cosA = dot(axis0, axis1);
-            if (cosA == 0) {
-                return vec2(dot(relPt, axis0), dot(relPt, axis1));
-            } else {
-                float argA = acos(cosA);
-                float sinA = sin(argA);
-                float tanA = tan(argA);
-                float cosB = dot(axis0, relPt) / relPt.length;
-                float argB = acos(cosB);
-                float sinB = sin(argB);
-                
-                vec2 ortPt = vec2(relPt.length * cosB, relPt.length * sinB);
-                
-                mat2 H = mat2([1, -1/tanA, 0, 1/sinA]);
-                auto result = H * ortPt;
-
-                return result;
-            }
-        }
-        vec2 calcDistanceFromNearestLine(vec2 pt, ref MeshData bindingMesh, ref int[] triangle) {
-            if( (pt - bindingMesh.vertices[triangle[0]]).lengthSquared > (pt - bindingMesh.vertices[triangle[1]]).lengthSquared) {
-                swap(triangle[0], triangle[1]);
-            }
-            if( (pt - bindingMesh.vertices[triangle[0]]).lengthSquared > (pt - bindingMesh.vertices[triangle[2]]).lengthSquared) {
-                swap(triangle[0], triangle[2]);
-            }
-            auto p1 = bindingMesh.vertices[triangle[0]];
-            auto p2 = bindingMesh.vertices[triangle[1]];
-            auto p3 = bindingMesh.vertices[triangle[2]];
-            vec2 axis0 = p2 - p1;
-            float axis0len = axis0.length;
-            axis0 /= axis0len;
-            auto relPt = pt - p1;
-            float arg = sign(axis0.y) * acos(axis0.x);
-            vec2 result = (mat3.identity().rotateZ(-arg) * vec3(relPt, 1)).xy;
-            result.x /= axis0len;
-            return result;
+            vec3 raxis1 = mat3([axis0.x, axis0.y, 0, -axis0.y, axis0.x, 0, 0, 0, 1]) * vec3(axis1, 1);
+            float cosA = raxis1.x;
+            float sinA = raxis1.y;
+            mat3 H = mat3([1, -cosA/sinA, 0, 
+                            0, 1/sinA, 0, 
+                            0, 0, 1]) * 
+                     mat3([axis0.x, axis0.y, 0, 
+                            -axis0.y, axis0.x, 0, 
+                            0, 0, 1]) * 
+                     mat3([1, 0, -(p1).x, 
+                            0, 1, -(p1).y, 
+                            0, 0, 1]);
+            return (H * vec3(pt.x, pt.y, 1)).xy;
         }
 
         // Apply transform for mesh
@@ -984,19 +956,6 @@ public:
             return p1 + axis0 * offset.x + axis1 * offset.y;
         }
 
-        // Calculate position of the vertex using coordinates of the triangle.      
-        vec2 transformPointToLine(vec2 pt, vec2 offset, vec2[] vertices, ref int[] triangle) {
-            auto p1 = vertices[triangle[0]];
-            auto p2 = vertices[triangle[1]];
-            auto p3 = vertices[triangle[2]];
-            vec2 axis0 = p2 - p1;
-            float axis0len = axis0.length;
-            axis0 /= axis0len;
-            float arg = sign(axis0.y) * acos(axis0.x);
-            vec2 axis1 = vec2(cos(arg + PI/2), sin(arg+PI/2));
-           return p1 + axis0 * axis0len * offset.x + axis1 * offset.y;
-        }
-        
         MeshData bindingMesh = part.getMesh();
         Deformation* newDeform = new Deformation([]);
 
@@ -1007,14 +966,10 @@ public:
                 pt.x = -pt.x;
             int[] triangle = findSurroundingTriangle(pt, bindingMesh);
             vec2 newPos;
-            if (triangle !is null) {
-                vec2 ofs = calcOffsetInTriangleCoords(pt, bindingMesh, triangle);
-                newPos = transformPointInTriangleCoords(pt, ofs, targetMesh, triangle);
-            } else {
+            if (triangle is null)
                 triangle = findNearestTriangle(pt, bindingMesh);
-                vec2 ofs = calcDistanceFromNearestLine(pt, bindingMesh, triangle);
-                newPos = transformPointToLine(pt, ofs, targetMesh, triangle);
-            }
+            vec2 ofs = calcOffsetInTriangleCoords(pt, bindingMesh, triangle);
+            newPos = transformPointInTriangleCoords(pt, ofs, targetMesh, triangle);
             if (flipHorz)
                 newPos.x = -newPos.x;
             newDeform.vertexOffsets ~= newPos - origVertices[i].position;

--- a/source/creator/widgets/mainmenu.d
+++ b/source/creator/widgets/mainmenu.d
@@ -420,6 +420,10 @@ void incMainMenu() {
                 if (igBeginMenu(__("Tools"), true)) {
                     import creator.utils.repair : incAttemptRepairPuppet, incRegenerateNodeIDs;
 
+                    if(igMenuItem(__("Model flip configuration..."), "", false, true)) {
+                        incPopWelcomeWindow();
+                        incPushWindow(new FlipPairWindow());
+                    }
                 
                     igTextColored(ImVec4(0.7, 0.5, 0.5, 1), __("Puppet Data"));
                     igSeparator();

--- a/source/creator/windows/flipconfig.d
+++ b/source/creator/windows/flipconfig.d
@@ -40,10 +40,14 @@ class FlipPair {
 
 private {
     FlipPair[] flipPairs;
-
+    Puppet activePuppet = null;
 }
 
 FlipPair[] incGetFlipPairs() {
+    if (incActivePuppet() != activePuppet) {
+        activePuppet = incActivePuppet();
+        flipPairs.length = 0;
+    }
     return flipPairs;
 }
 
@@ -373,7 +377,7 @@ public:
     this() {
         auto puppet = incActivePuppet();
         nodes = puppet.findNodesType!Node(puppet.root);
-        pairs = flipPairs.dup;
+        pairs = incGetFlipPairs().dup;
         foreach (i, pair; pairs) {
             if (pair.parts[0] !is null)
                 map[pair.parts[0].uuid] = i;

--- a/source/creator/windows/flipconfig.d
+++ b/source/creator/windows/flipconfig.d
@@ -80,7 +80,7 @@ private:
             string targetName = node.name.replace(part1, part2);
             if (node.uuid in map) continue;
             foreach (ref Node node2; nodes) {
-                if (node2.name == targetName) {
+                if (node.name.indexOf(part1) >= 0 && node2.name == targetName) {
                     if (node2.uuid != node.uuid) {
                         pairs ~= new FlipPair([node, node2], "");
                         map[node.uuid] = pairs.length - 1;

--- a/source/creator/windows/flipconfig.d
+++ b/source/creator/windows/flipconfig.d
@@ -1,0 +1,387 @@
+/*
+    Copyright © 2020-2023, Inochi2D Project
+    Distributed under the 2-Clause BSD License, see LICENSE file.
+    
+    Authors: Luna Nielsen
+*/
+module creator.windows.flipconfig;
+import creator.windows;
+import creator.core;
+import creator.widgets;
+import creator;
+import creator.ext;
+import std.string;
+import creator.utils.link;
+import inochi2d;
+import i18n;
+import psd;
+import std.uni : toLower;
+import std.stdio : File;
+import std.string;
+import std.algorithm.searching : canFind, countUntil;
+
+/**
+    Binding between layer and node
+*/
+
+class FlipPair {
+    Node[2] parts;
+    string name;
+    this(Node[2] parts, string name) {
+        this.parts = parts;
+        this.name = name;
+        this.update();
+    }
+    void flip() {}
+    void update () {
+        name = "%s <-> %s".format((parts[0] !is null)? parts[0].name: "", (parts[1] !is null)? parts[1].name: "");
+    }
+};
+
+private {
+    FlipPair[] flipPairs;
+
+}
+
+FlipPair[] incGetFlipPairs() {
+    return flipPairs;
+}
+
+FlipPair incGetFlipPairFor(Node node) {
+    foreach (pair; flipPairs) {
+        if (pair.parts[0].uuid == node.uuid || pair.parts[1].uuid == node.uuid) {
+            return pair;
+        }
+    }
+    return null;
+}
+
+class FlipPairWindow : Window {
+private:
+
+    string nodeFilter;
+    string part1Pattern;
+    string part2Pattern;
+
+    enum PreviewSize = 128f;
+    Node[] nodes;
+    ulong[uint] map;
+    FlipPair[] pairs;
+
+    FlipPair* active = null;
+
+    void apply() {
+        flipPairs = pairs;
+    }
+
+
+    void autoPair(string part1, string part2) {
+        foreach(i, ref Node node; nodes) {
+            string targetName = node.name.replace(part1, part2);
+            if (node.uuid in map) continue;
+            foreach (ref Node node2; nodes) {
+                if (node2.name == targetName) {
+                    if (node2.uuid != node.uuid) {
+                        pairs ~= new FlipPair([node, node2], "");
+                        map[node.uuid] = pairs.length - 1;
+                        map[node2.uuid] = pairs.length - 1;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+
+    vec4 previewImage(Part part, ImVec2 centerPos, float previewSize, ImVec2 uv0 = ImVec2(0, 0), ImVec2 uv1 = ImVec2(1, 1), ImVec4 tintColor=ImVec4(1, 1, 1, 1)) {
+        if (part.textures[0].width < previewSize && part.textures[0].height < previewSize)
+            previewSize = max(part.textures[0].width, part.textures[0].height);
+
+        float widthScale = previewSize / cast(float)part.textures[0].width;
+        float heightScale = previewSize / cast(float)part.textures[0].height;
+        float fscale = min(widthScale, heightScale);
+        
+        vec4 bounds = vec4(0, 0, part.textures[0].width*fscale, part.textures[0].height*fscale);
+        if (widthScale > heightScale) bounds.x = (previewSize-bounds.z)/2;
+        else if (widthScale < heightScale) bounds.y = (previewSize-bounds.w)/2;
+
+        ImVec2 tl;
+        igGetCursorPos(&tl);
+
+        igItemSize(ImVec2(PreviewSize, PreviewSize));
+
+        igSetCursorPos(
+            ImVec2(tl.x+centerPos.x-previewSize/2+bounds.x, tl.y+centerPos.y-previewSize/2+bounds.y)
+        );
+
+        igImage(
+            cast(void*)part.textures[0].getTextureId(), 
+            ImVec2(bounds.z, bounds.w), uv0, uv1, tintColor
+        );
+        return bounds;
+
+    }
+
+    void treeView() {
+
+        import std.algorithm.searching : canFind;
+        foreach(i, ref Node node; nodes) {
+            if (nodeFilter.length > 0 && !node.name.toLower.canFind(nodeFilter.toLower)) continue;
+            if (node.uuid in map) continue;
+
+            igPushID(cast(int)i);
+
+            igSelectable(node.cName, false, ImGuiSelectableFlagsI.SpanAvailWidth);
+
+            if(igBeginDragDropSource(ImGuiDragDropFlags.SourceAllowNullID)) {
+                igSetDragDropPayload("__PAIRING", cast(void*)&node, (&node).sizeof, ImGuiCond.Always);
+                igText(node.cName);
+                igEndDragDropSource();
+            }
+
+            // Incredibly cursed preview image
+            if (igIsItemHovered()) {
+                igBeginTooltip();
+                    incText(node.name);
+                    // Calculate render size
+                    if (auto part = cast(Part)node) {
+                        vec4 bounds = previewImage(part, ImVec2(PreviewSize/2, PreviewSize/2), PreviewSize);
+                    }
+                igEndTooltip();
+            }
+            igPopID();
+        }
+
+    }
+
+    void pairView() {
+
+        import std.stdio;
+
+        foreach(i, ref FlipPair pair; pairs) {
+
+            igPushID(cast(int)i);
+
+            igTableNextRow();
+            igTableNextColumn();
+            igSelectable("##%s".format(pair.parts[0].cName).toStringz, true, ImGuiSelectableFlags.SpanAllColumns);
+            if (igIsItemClicked()) {
+                active = &pair;
+            }
+            igSameLine();
+            igLabelText("##Target%d".format(i).toStringz, pair.parts[0].cName);
+            // Only allow reparenting one node
+            if(igBeginDragDropTarget()) {
+                const(ImGuiPayload)* payload = igAcceptDragDropPayload("__PAIRING");
+                if (payload !is null) {
+                    Node node = *cast(Node*)payload.Data;
+
+                    FlipPair* targetPair = null;
+                    foreach (pair2; pairs) {
+                        if (pair2.parts[0].uuid == node.uuid || pair2.parts[1] && pair2.parts[1].uuid == node.uuid) {
+                            targetPair = &pair2;
+                            break;
+                        }
+                    }
+                    writefln("parts[0]: flippable set=%s, node=%s", targetPair, node);
+                    if (targetPair !is null && targetPair != &pair) {
+                        if ((*targetPair).parts[0].uuid == node.uuid) {
+                            (*targetPair).parts[0] = null;
+                        } else {
+                            (*targetPair).parts[1] = null;
+                        }
+                    }
+                    pair.parts[0] = node;
+                    map[node.uuid] = i;
+                    pair.update();
+                    writefln("set parts[0]: name=%s", pair.name);
+
+                    igEndDragDropTarget();
+                    igPopID();
+                    return;
+                }
+                igEndDragDropTarget();
+            }
+
+            igTableNextColumn();
+            igLabelText("##Paired%d".format(i).toStringz, pair.parts[1]? pair.parts[1].cName: "-");
+            // Only allow reparenting one node
+            if(igBeginDragDropTarget()) {
+                const(ImGuiPayload)* payload = igAcceptDragDropPayload("__PAIRING");
+                if (payload !is null) {
+                    Node node = *cast(Node*)payload.Data;
+
+                    FlipPair* targetPair = null;
+                    foreach (pair2; pairs) {
+                        if (pair2.parts[0].uuid == node.uuid || pair2.parts[1] && pair2.parts[1].uuid == node.uuid) {
+                            targetPair = &pair2;
+                            break;
+                        }
+                    }
+                    writefln("pair: flippable set=%s, node=%s", targetPair, node);
+                    if (targetPair !is null && targetPair != &pair) {
+                        if ((*targetPair).parts[0].uuid == node.uuid) {
+                            (*targetPair).parts[0] = null;
+                        } else {
+                            (*targetPair).parts[1] = null;
+                        }
+                    }
+                    pair.parts[1] = node;
+                    map[node.uuid] = i;
+                    pair.update();
+                    writefln("set parts[1]: name=%s", pair.name);
+
+                    igEndDragDropTarget();
+                    igPopID();
+                    return;
+                }
+                igEndDragDropTarget();
+            }
+            igPopID();
+
+        }
+
+        igTableNextRow();
+        igTableNextColumn();
+        igText(__("< Add new row >"));
+    }
+
+protected:
+
+    override
+    void onBeginUpdate() {
+        igSetNextWindowSizeConstraints(ImVec2(960, 480), ImVec2(float.max, float.max));
+        super.onBeginUpdate();
+    }
+
+    override
+    void onUpdate() {
+        ImVec2 space = incAvailableSpace();
+        float gapspace = 8;
+        float childWidth = (space.x/3);
+        float childHeight = space.y-(24);
+        float filterWidgetHeight = 24;
+        float optionsListHeight = 24;
+
+        igBeginGroup();
+            if (igBeginChild("###Nodes", ImVec2(childWidth, childHeight))) {
+                incInputText("##", childWidth, nodeFilter);
+
+                igBeginListBox("###NodeList", ImVec2(childWidth, childHeight-filterWidgetHeight-optionsListHeight));
+                    treeView();
+                igEndListBox();
+            }
+            igEndChild();
+
+            igSameLine(0, gapspace);
+
+            if (igBeginChild("###Pairs", ImVec2(childWidth, childHeight))) {
+                incInputText("##part1", (childWidth - 32) / 2, part1Pattern);
+                igSameLine(0, 0);
+                if (igButton(__("Go"), ImVec2(32, 0))) {
+                    autoPair(part1Pattern, part2Pattern);
+                }
+                igSameLine(0, 0);
+                incInputText("##part2", (childWidth - 32) / 2, part2Pattern);
+                
+                igBeginTable("###PairsTable", 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders, ImVec2(childWidth-gapspace, childHeight-optionsListHeight));
+                    igTableHeader("###PairsTableHeader");
+                    igTableSetupColumn("part 1", ImGuiTableColumnFlags.WidthStretch);
+                    igTableSetupColumn("part 2", ImGuiTableColumnFlags.WidthStretch);
+                    igTableHeadersRow();
+                    pairView();
+                igEndTable();
+                if(igBeginDragDropTarget()) {
+                    import std.stdio;
+                    const(ImGuiPayload)* payload = igAcceptDragDropPayload("__PAIRING");
+                    if (payload !is null) {
+                        Node node = *cast(Node*)payload.Data;
+                        FlipPair* targetPair = null;
+                        foreach (pair; pairs) {
+                            if (pair.parts[0].uuid == node.uuid || pair.parts[1] !is null && pair.parts[1].uuid == node.uuid) {
+                                targetPair = &pair;
+                                break;
+                            }
+                        }
+                        writefln("flippable set=%s, node=%s", targetPair, node);
+                        if (targetPair is null) {
+                            pairs ~= new FlipPair([node, null], null);
+                            map[node.uuid] = pairs.length - 1;
+                        }
+                    }
+                    igEndDragDropTarget();
+                }
+
+            }
+            igEndChild();
+
+            igSameLine(0, gapspace);
+
+            if (igBeginChild("###Preview", ImVec2(childWidth, childHeight))) {
+                vec4 bounds;               
+                if (active !is null) {
+                    float previewSize = min(childWidth, childHeight);
+                    ImVec2 tl;
+                    igGetCursorPos(&tl);
+                    if ((*active).parts[0] && cast(Part)(active.parts[0]))
+                        bounds = previewImage(cast(Part)(active.parts[0]), ImVec2(childWidth / 2, childHeight / 2), previewSize, ImVec2(0, 0), ImVec2(1, 1), ImVec4(1, 1, 1, 0.6));
+                    igSetCursorPos(tl);
+                    if ((*active).parts[1] && cast(Part)(active.parts[1]))
+                        previewImage(cast(Part)(active.parts[1]), ImVec2(childWidth / 2, childHeight / 2), previewSize, ImVec2(1, 0), ImVec2(0, 1), ImVec4(1, 1, 1, 0.6));
+                }
+
+            }
+            igEndChild();
+
+        igEndGroup();
+
+
+        igBeginGroup();
+
+            // Spacer
+            space = incAvailableSpace();
+            incSpacer(ImVec2(-(140), 32));
+
+            // 
+            if (igButton(__("Cancel"), ImVec2(64, 24))) {
+                this.close();
+                
+                igEndGroup();
+                return;
+            }
+            igSameLine(0, 0);
+            if (igButton(__("Save"), ImVec2(64, 24))) {
+                apply();
+                this.close();
+                
+                igEndGroup();
+                return;
+            }
+        igEndGroup();
+    }
+
+    override
+    void onClose() {
+        import core.memory : GC;
+        GC.collect();
+        GC.minimize();
+    }
+
+public:
+    ~this() { }
+
+    this() {
+        auto puppet = incActivePuppet();
+        nodes = puppet.findNodesType!Node(puppet.root);
+        pairs = flipPairs.dup;
+        foreach (i, pair; pairs) {
+            if (pair.parts[0] !is null)
+                map[pair.parts[0].uuid] = i;
+            if (pair.parts[1] !is null)
+                map[pair.parts[1].uuid] = i;
+        }
+
+        super(_("Flip Pairing"));
+    }
+}
+

--- a/source/creator/windows/package.d
+++ b/source/creator/windows/package.d
@@ -23,6 +23,7 @@ public import creator.windows.psdmerge;
 public import creator.windows.welcome;
 public import creator.windows.rename;
 public import creator.windows.imgexport;
+public import creator.windows.flipconfig;
 
 version(NoUIScaling) private ImGuiWindowClass* windowClass;
 


### PR DESCRIPTION
Implemented auto-flip for deformers.
Currently, "Mirrored Autofill" and "Set from mirror" operations are altered for new algorithm.

This patch includes two parts:
1) Flip paring configuration dialog. (Tool -> model flip configuration)
2) Update of logics for "mirrored autofill" and "set from mirror" operation.

Basic usage:
1) specify pairs of nodes to use in flip opertion.
2) Flip deformation from parameters panel.
If no pair is specified, application acts as same as before.