### PR TITLE
Suggestion to change parameter structure in the model.

### DIFF
--- a/source/creator/ext/package.d
+++ b/source/creator/ext/package.d
@@ -146,10 +146,10 @@ public:
     }
 
     override
-    void restructure() {
-        super.restructure();
+    void restruct() {
+        super.restruct();
         foreach(group; groups.dup) {
-            group.restructure(this);
+            group.restruct(this);
         }
     }
 

--- a/source/creator/ext/package.d
+++ b/source/creator/ext/package.d
@@ -27,13 +27,6 @@ public:
     override
     Parameter findParameter(uint uuid) {
         foreach(ref parameter; parameters) {
-            /*
-            if (auto group = cast(ExParameterGroup)parameter) {
-                foreach(ref child; group.children) {
-                    if (child.uuid == uuid) return child;
-                }
-            } else
-            */
             if (parameter.uuid == uuid) return parameter;
         }
         return null;
@@ -41,17 +34,10 @@ public:
     
 
     /**
-        Returns a parameter by UUID
+        Returns a parameter by name
     */
     Parameter findParameter(string name) {
         foreach(ref parameter; parameters) {
-            /*            
-            if (auto group = cast(ExParameterGroup)parameter) {
-                foreach(ref child; group.children) {
-                    if (child.name == name) return child;
-                }
-            } else
-            */
             if (parameter.name == name) return parameter;
         }
         return null;
@@ -84,6 +70,8 @@ public:
         ptrdiff_t idx = parameters.countUntil(param);
         if (idx >= 0) {
             parameters = parameters.remove(idx);
+            if (auto exParam = cast(ExParameter)param)
+                exParam.setParent(null);
             return;
         }
 

--- a/source/creator/ext/package.d
+++ b/source/creator/ext/package.d
@@ -146,10 +146,10 @@ public:
     }
 
     override
-    void restruct() {
-        super.restruct();
+    void reconstruct() {
+        super.reconstruct();
         foreach(group; groups.dup) {
-            group.restruct(this);
+            group.reconstruct(this);
         }
     }
 

--- a/source/creator/ext/param.d
+++ b/source/creator/ext/param.d
@@ -45,7 +45,7 @@ public:
     }
 
     override
-    void restructure(Puppet _puppet) {
+    void restruct(Puppet _puppet) {
         auto puppet = cast(ExPuppet)_puppet;
         assert(puppet !is null);
         foreach (child; children) {
@@ -61,7 +61,7 @@ public:
             puppet.removeParameter(this);
             puppet.addGroup(this);
         }
-        super.restructure(_puppet);
+        super.restruct(_puppet);
     }
 
 }

--- a/source/creator/ext/param.d
+++ b/source/creator/ext/param.d
@@ -103,7 +103,7 @@ public:
     void setParent(ExParameterGroup newParent) {
         if (parent !is null && parent != newParent) {
             auto index = parent.children.countUntil(this);
-            if (index > 0)
+            if (index >= 0)
                 parent.children = parent.children.remove(index);
         }
         auto oldParent = parent;

--- a/source/creator/ext/param.d
+++ b/source/creator/ext/param.d
@@ -45,7 +45,7 @@ public:
     }
 
     override
-    void restruct(Puppet _puppet) {
+    void reconstruct(Puppet _puppet) {
         auto puppet = cast(ExPuppet)_puppet;
         assert(puppet !is null);
         foreach (child; children) {
@@ -61,7 +61,7 @@ public:
             puppet.removeParameter(this);
             puppet.addGroup(this);
         }
-        super.restruct(_puppet);
+        super.reconstruct(_puppet);
     }
 
 }


### PR DESCRIPTION
This patch suggest to change the structure of ExParameterGroup and Parameter.
After loaded ExParameterGroup under the "params" section, those groups are moved to "groups" section.
all of the children parameters are remained in the "params" section.
by this patch, iterating parameters becomes simple. There's no need to check whether parameter is group or not.

This patch depends on PR in [ inochi2d#37.](https://github.com/Inochi2D/inochi2d/pull/37)