### PR TITLE
Add function to autosave the project

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -15,6 +15,7 @@ import creator.widgets;
 import creator.core.actionstack;
 import creator.core.i18n;
 import creator.io;
+import creator.io.autosave;
 import creator.atlas.atlas : incInitAtlassing;
 import creator.ext;
 import creator.windows.flipconfig;
@@ -120,7 +121,7 @@ void incUpdate() {
     incAnimationUpdate();
     inUpdate();
 
-    checkAutosave();
+    incCheckAutosave();
 
     // Begin IMGUI loop
     incBeginLoop();

--- a/source/app.d
+++ b/source/app.d
@@ -120,6 +120,8 @@ void incUpdate() {
     incAnimationUpdate();
     inUpdate();
 
+    checkAutosave();
+
     // Begin IMGUI loop
     incBeginLoop();
         if (incShouldProcess()) {

--- a/source/creator/core/package.d
+++ b/source/creator/core/package.d
@@ -14,6 +14,7 @@ import creator.utils.link;
 import creator;
 import creator.widgets.dialog;
 import creator.backend.gl;
+import creator.io.autosave;
 
 import std.exception;
 
@@ -765,6 +766,7 @@ void incExit() {
     incSettingsSet("WinW", w);
     incSettingsSet("WinH", h);
     incSettingsSet!bool("WinMax", (flags & SDL_WINDOW_MAXIMIZED) > 0);
+    incReleaseLockfile();
 }
 
 /**

--- a/source/creator/io/autosave.d
+++ b/source/creator/io/autosave.d
@@ -1,0 +1,158 @@
+module creator.io.autosave;
+
+import creator.windows.autosave;
+import creator.core;
+import creator;
+import i18n;
+
+import std.file;
+import std.path;
+import std.datetime;
+import std.datetime.stopwatch : benchmark, StopWatch;
+
+private {
+    StopWatch autosaveTimer;
+    immutable string projectLockfile = "creator-project.lock";
+}
+
+public void startAutosaveTimer() {
+    autosaveTimer.start();
+}
+
+string[] incGetPrevAutosaves() {
+    return incSettingsGet!(string[])("prev_autosaves");
+}
+
+void incAddPrevAutosave(string path) {
+    import std.algorithm.searching : countUntil;
+    import std.algorithm.mutation : remove;
+    string[] autosaves = incGetPrevAutosaves();
+
+    ptrdiff_t idx = autosaves.countUntil(path);
+    if (idx >= 0) {
+        autosaves = autosaves.remove(idx);
+    }
+
+    // Put project to the start of the "previous" list and
+    // limit to 10 elements
+    autosaves = path.dup ~ autosaves;
+    //(currProjectPath)
+    if(autosaves.length > 10) autosaves.length = 10;
+
+    // Then save.
+    incSettingsSet("prev_autosaves", autosaves);
+    incSettingsSave();
+}
+
+/**
+    Autosave the project if enough time has passed since last autosave.
+*/
+void incCheckAutosave() {
+    if (incProjectPath.length == 0) {
+        //Do nothing, there's nothing to autosave.
+        return;
+    }
+    
+    auto elapsedSeconds = autosaveTimer.peek().total!"seconds";
+    if (elapsedSeconds >= 300) {
+        //TODO: Add a user setting instead of hardcoding.
+        incAutosaveProject(incProjectPath);
+        autosaveTimer.reset();
+    }
+}
+
+/**
+    Save the project as a rolling backup.
+    Doesn't overwrite the main save file.
+*/
+void incAutosaveProject(string path) {
+    //We'll add the extension back later when we need it.
+    path = path.stripExtension;
+
+    string pathBaseName = path.baseName;
+
+    string backupDir = getAutosaveDir(path);
+    mkdirRecurse(backupDir);
+    path = buildPath(backupDir, pathBaseName);
+
+    auto entries = currentBackups(backupDir);
+    while (entries.length >= 10) {
+        //TODO: Add a user setting instead of hardcoding.
+        std.file.remove(entries[0]);
+        entries = currentBackups(backupDir);
+    }
+
+    // Leave off the .inx extension because it's added by incSaveProject.
+    incSaveProject(path, bakStampString());
+    incCreateLockfile(path);
+}
+
+/**
+    Create a backup save path string.
+*/
+string bakStampString() {
+    string bakName = Clock.currTime.toISOExtString();
+    return bakName;
+}
+
+/**
+    Finds the appropriate directory for storing autosaves that corresponds
+    to the given project.
+*/
+string getAutosaveDir(string projectPath) {
+    string pathBaseName = projectPath.baseName;
+    string autosaveDir = buildPath(incGetAppConfigPath(), "autosaves", pathBaseName);
+    return autosaveDir;
+}
+
+auto currentBackups(string projectAutosaveDir) {
+    import std.algorithm;
+    import std.array;
+    auto entries = dirEntries(projectAutosaveDir, "*.inx", SpanMode.shallow)
+        .filter!(a => a.isFile)
+        .array;
+    return entries;
+}
+
+/**
+    Create the project session's lockfile.
+    Does nothing if there already is one for the project.
+    This should be called after we have created a backup file which can be
+    used to recover from a crash.
+*/
+void incCreateLockfile(string projectPath) {
+    projectPath = projectPath.stripExtension;
+    string lockfileDir = getAutosaveDir(projectPath);
+    string lockfile = buildPath(lockfileDir, projectLockfile);
+    mkdirRecurse(lockfileDir);
+    write(lockfile, "");
+}
+
+/**
+    Remove the project session's lockfile, if there is one.
+    This should be called during normal app/project close procedure,
+    and when manually saving (it will return on next autosave).
+*/
+void incReleaseLockfile() {
+    string projectPath = incProjectPath.stripExtension;
+    if (projectPath.length == 0) return;
+    string lockfileDir = getAutosaveDir(projectPath);
+    string lockfile = buildPath(lockfileDir, projectLockfile);
+    if (lockfile.exists) {
+        lockfile.remove;
+    }
+
+    // If the lockfile doesn't exist, it was probably too soon to create anyway.
+}
+
+/**
+    Check to see if a project session's lockfile exists.
+    The presence of this lockfile indicates an autosave may be more recent
+    than the main save file.
+*/
+bool incCheckLockfile(string projectPath) {
+    projectPath = projectPath.stripExtension;
+    string lockfileDir = getAutosaveDir(projectPath);
+    string lockfile = buildPath(lockfileDir, projectLockfile);
+    return lockfile.exists;
+}

--- a/source/creator/widgets/mainmenu.d
+++ b/source/creator/widgets/mainmenu.d
@@ -12,6 +12,7 @@ import creator.core;
 import creator.core.input;
 import creator.utils.link;
 import creator.config;
+import creator.io.autosave;
 import creator;
 import inochi2d;
 import inochi2d.core.dbg;
@@ -134,9 +135,27 @@ void incMainMenu() {
                     }
 
                     string[] prevProjects = incGetPrevProjects();
+                    string[] prevAutosaves = incGetPrevAutosaves();
                     if (igBeginMenu(__("Recent"), prevProjects.length > 0)) {
+                        import std.path : baseName;
+                        if (igBeginMenu(__("Autosaves"), prevAutosaves.length > 0)) {
+                            foreach(autosave; prevAutosaves) {
+                                if (igMenuItem(autosave.baseName.toStringz, "", false, true)) {
+                                    /**
+                                        TODO: we want to open autosaves a special way.
+                                        A way that opens that file up,
+                                        but sets the main project file properly.
+                                        To do this, we first need to store
+                                        autosaves as a tuple to contain the original
+                                        main project path.
+                                    */
+                                }
+                                incTooltip(autosave);
+                            }
+                            igEndMenu();
+                        }
+
                         foreach(project; incGetPrevProjects) {
-                            import std.path : baseName;
                             if (igMenuItem(project.baseName.toStringz, "", false, true)) {
                                 incPopWelcomeWindow();
                                 incOpenProject(project);

--- a/source/creator/widgets/mainmenu.d
+++ b/source/creator/widgets/mainmenu.d
@@ -135,22 +135,20 @@ void incMainMenu() {
                     }
 
                     string[] prevProjects = incGetPrevProjects();
-                    string[] prevAutosaves = incGetPrevAutosaves();
+                    AutosaveRecord[] prevAutosaves = incGetPrevAutosaves();
                     if (igBeginMenu(__("Recent"), prevProjects.length > 0)) {
                         import std.path : baseName;
                         if (igBeginMenu(__("Autosaves"), prevAutosaves.length > 0)) {
-                            foreach(autosave; prevAutosaves) {
-                                if (igMenuItem(autosave.baseName.toStringz, "", false, true)) {
-                                    /**
-                                        TODO: we want to open autosaves a special way.
-                                        A way that opens that file up,
-                                        but sets the main project file properly.
-                                        To do this, we first need to store
-                                        autosaves as a tuple to contain the original
-                                        main project path.
-                                    */
+                            foreach(saveRecord; prevAutosaves) {
+                                auto autosavePath = saveRecord.autosavePath.baseName.toStringz;
+                                if (igMenuItem(autosavePath, "", false, true)) {
+                                    incPopWelcomeWindow();
+                                    incOpenProject(
+                                        saveRecord.mainsavePath,
+                                        saveRecord.autosavePath
+                                    );
                                 }
-                                incTooltip(autosave);
+                                incTooltip(saveRecord.autosavePath);
                             }
                             igEndMenu();
                         }

--- a/source/creator/windows/autosave.d
+++ b/source/creator/windows/autosave.d
@@ -1,0 +1,64 @@
+module creator.windows.autosave;
+
+import creator;
+import creator.windows;
+import creator.widgets;
+import creator.widgets.dummy;
+import creator.widgets.label : incText;
+import creator.io.autosave;
+import i18n;
+import std.path : stripExtension;
+
+class RestoreSaveWindow : Window {
+private:
+    string projectPath;
+
+protected:
+    override
+    void onBeginUpdate() {
+        ImVec2 middlepos = ImVec2(
+            igGetMainViewport().Pos.x+(igGetMainViewport().Size.x/2),
+            igGetMainViewport().Pos.y+(igGetMainViewport().Size.y/2),
+        );
+        igSetNextWindowPos(middlepos, ImGuiCond.Appearing, ImVec2(0.5, 0.5));
+        igSetNextWindowSize(ImVec2(400, 128), ImGuiCond.Appearing);
+        igSetNextWindowSizeConstraints(ImVec2(400, 128), ImVec2(float.max, float.max));
+        super.onBeginUpdate();
+    }
+
+    override
+    void onUpdate() {
+        float availX = incAvailableSpace().x;
+        if (igBeginChild("RestoreSaveMessage", ImVec2(0, -28), true)) {
+            incText(_("Previous Inochi Creator session closed unexpectedly."));
+            incText(_("Restore unsaved data?"));
+        }
+        igEndChild();
+
+        if (igBeginChild("RestoreSaveButtons", ImVec2(0, 0), false, ImGuiWindowFlags.NoScrollbar)) {
+            incDummy(ImVec2(-128, 0));
+            igSameLine(0, 0);
+
+            if (igButton(__("No"), ImVec2(64, 24))) {
+                incOpenProject(projectPath, "");
+                this.close();
+                incPopWelcomeWindow();
+            }
+            igSameLine(0, 0);
+
+            if (igButton(__("Yes"), ImVec2(64, 24))) {
+                string backupDir = getAutosaveDir(projectPath.stripExtension);
+                auto entries = currentBackups(backupDir);
+                incOpenProject(projectPath, entries[$-1]);
+                this.close();
+                incPopWelcomeWindow();
+            }
+        }
+        igEndChild();
+    }
+public:
+    this(string projectPath) {
+        super(_("Restore Autosave"));
+        this.projectPath = projectPath;
+    }
+}

--- a/source/creator/windows/settings.d
+++ b/source/creator/windows/settings.d
@@ -9,6 +9,7 @@ import creator.windows;
 import creator.widgets;
 import creator.core;
 import creator.core.i18n;
+import creator.io.autosave;
 import std.string;
 import creator.utils.link;
 import i18n;
@@ -19,7 +20,8 @@ bool incIsSettingsOpen;
 enum SettingsPane : string {
     LookAndFeel = "Look and Feel",
     Viewport = "Viewport",
-    Accessibility = "Accessbility"
+    Accessibility = "Accessbility",
+    Autosaves = "Autosaves"
 }
 
 /**
@@ -84,6 +86,10 @@ protected:
                 
                 if (igSelectable(__("Accessbility"), settingsPane == SettingsPane.Accessibility)) {
                     settingsPane = SettingsPane.Accessibility;
+                }
+
+                if (igSelectable(__("Autosaves"), settingsPane == SettingsPane.Autosaves)) {
+                    settingsPane = SettingsPane.Autosaves;
                 }
             igPopTextWrapPos();
         }
@@ -161,6 +167,24 @@ protected:
                                 changesRequiresRestart = true;
                             }
                             incTooltip("Use the OpenDyslexic font for Latin text characters.");
+                        endSection();
+                        break;
+                    case SettingsPane.Autosaves:
+                        beginSection(__("Autosaves"));
+                            bool autosaveEnabled = incGetAutosaveEnabled();
+                            if (igCheckbox(__("Enable Autosaves"), &autosaveEnabled)) {
+                                incSetAutosaveEnabled(autosaveEnabled);
+                            }
+
+                            int autosaveFreq = incGetAutosaveInterval();
+                            if (igInputInt(__("Save Interval (Minutes)"), &autosaveFreq, 5, 15, ImGuiInputTextFlags.EnterReturnsTrue)) {
+                                incSetAutosaveInterval(autosaveFreq);
+                            }
+
+                            int saveFileLimit = incGetAutosaveFileLimit();
+                            if (igInputInt(__("Maximum Autosaves"), &saveFileLimit, 1, 5, ImGuiInputTextFlags.EnterReturnsTrue)) {
+                                incSetAutosaveFileLimit(saveFileLimit);
+                            }
                         endSection();
                         break;
                     default:


### PR DESCRIPTION
The autosaves are implemented here in a rolling backup fashion, such that the 10 most recent autosaves are kept. The autosaves don't overwrite the main save file. The changes include modifying the `incSaveProject` function in order to avoid adding the autosave files to the list of previous projects.

I thought it would be good to get this PR going with what I have now so I could incorporate feedback sooner rather than later.

Things not included in this PR that will likely still be needed:

- Ability to turn the autosave feature on/off.
- Ability to configure how many backups are kept.
- Ability to configure how often to trigger the autosave.
- Improve the performance of the filesave so that the program doesn't freeze as long during autosave. This might not be as important but I did notice it during testing.