### PR TITLE
Adjust-origin: adjust center of nodes / meshgroups from bounding box of children.

### DIFF
--- a/source/creator/panels/nodes.d
+++ b/source/creator/panels/nodes.d
@@ -34,13 +34,13 @@ protected:
         }
     }
 
-    void adjustNodeOrigin(Node node, bool recursive = true) {
+    void recalculateNodeOrigin(Node node, bool recursive = true) {
         auto mgroup = cast(MeshGroup)node;
         auto drawable = cast(Drawable)node;
 
         if (recursive) {
             foreach (child; node.children) {
-                adjustNodeOrigin(child, recursive);
+                recalculateNodeOrigin(child, recursive);
             }
         }
         if (mgroup !is null || drawable is null) {
@@ -183,8 +183,8 @@ protected:
                     igEndMenu();
                 }
 
-                if (igMenuItem(__("Adjust origin"), "", false, true)) {
-                    adjustNodeOrigin(n, true);
+                if (igMenuItem(__("Recalculate origin"), "", false, true)) {
+                    recalculateNodeOrigin(n, true);
                 }
             }
             igEndPopup();


### PR DESCRIPTION
When new nodes are added origin of its node is same as the one of parent.
If user added nodes iteratively, and then add Drawable and Parts to the node, origin of node is always at the center of the puppet. Rigger have to correct the position manually after build hierarchy structure of the parts.

This new function can adjust the position of Node, Composite, Physics, MeshGroup etc (means other than Part object) automatically based on the bounding box of the children nodes. function can eliminate much of boring tasks of adjustment of the origin.
And this function calculate the position of the child recursively, so rigger have to run this functions only once at root node.