### PR TITLE
bug fix: Parameters moved from root to Parameter Group is not handled correctly.

### DIFF
--- a/source/creator/ext/param.d
+++ b/source/creator/ext/param.d
@@ -6,7 +6,7 @@ import creator;
 import creator.ext;
 
 import std.algorithm.searching;
-import std.algorithm.mutation;
+import std.algorithm.mutation: remove;
 
 class ExParameterGroup : Parameter {
 protected:
@@ -104,8 +104,9 @@ public:
     void setParent(ExParameterGroup newParent) {
         if (parent !is null && parent != newParent) {
             auto index = parent.children.countUntil(this);
-            if (index >= 0)
+            if (index >= 0) {
                 parent.children = parent.children.remove(index);
+            }
         }
         auto oldParent = parent;
         parent = newParent;

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -778,12 +778,11 @@ private {
         if (idx < 0) return false;
 
         if (parent) {
-            if (parent.children.length > 1) parent.children = parent.children.remove(idx);
+            if (parent.children.length > 0) parent.children = parent.children.remove(idx);
             else parent.children.length = 0;
-        } else {
-            if (incActivePuppet().parameters.length > 1) incActivePuppet().parameters = incActivePuppet().parameters.remove(idx);
-            else incActivePuppet().parameters.length = 0;
-        } 
+        }
+        if (incActivePuppet().parameters.length > 1) incActivePuppet().parameters = incActivePuppet().parameters.remove(idx);
+        else incActivePuppet().parameters.length = 0;
 
         return true;
     }
@@ -840,11 +839,9 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
                     if (payload !is null) {
                         ParamDragDropData* payloadParam = *cast(ParamDragDropData**)payload.Data;
 
-                        if (removeParameter(param)) {
-                            auto group = createParamGroup(cast(int)idx);
-                            group.children ~= param;
-                            moveParameter(payloadParam.param, group);
-                        }
+                        auto group = createParamGroup(cast(int)idx);
+                        moveParameter(param, group);
+                        moveParameter(payloadParam.param, group);
                     }
                     igEndDragDropTarget();
                 }


### PR DESCRIPTION
Fixed two bugs:
1) Parameter was not saved under following condition.
   a) parameter was not owned by any parameter group at first.
   b) parameter was moved to a parameter group in parameter panel.

2) First child of parameter group is not handled correctly, and cannot be removed from parameter group.
------
bug 1 was caused because unowned parameters are removed before added to ExParameterGroup before, but currently it must not be removed from puppet.parameters.

bug 2 was caused because first child was directly added to ExParameterGroup.children before, but now it have to be passed to moveParameter function.