### PR TITLE
bug fix: workaround for https://github.com/Inochi2D/inochi-creator/issues/109 and https://github.com/Inochi2D/inochi-creator/issues/233

### DIFF
--- a/source/creator/actions/parameter.d
+++ b/source/creator/actions/parameter.d
@@ -12,6 +12,7 @@ import creator;
 import inochi2d;
 import std.format;
 import i18n;
+import std.algorithm.searching: countUntil;
 
 /**
     Action to add parameter to active puppet.
@@ -59,7 +60,7 @@ public:
         auto exParam = cast(ExParameter)self;
         if (exParam !is null) {
             originalParent = exParam.getParent();
-            indexInGroup = originalParent? originalParent.countUntil(exParam): -1;
+            indexInGroup = originalParent? originalParent.children.countUntil(exParam): -1;
         }
         if (!added) {
             incActivePuppet().parameters ~= self;
@@ -87,7 +88,7 @@ public:
         auto exParam = cast(ExParameter)self;
         if (exParam !is null) {
             originalParent = exParam.getParent();
-            indexInGroup = originalParent? originalParent.countUntil(exParam): -1;
+            indexInGroup = originalParent? originalParent.children.countUntil(exParam): -1;
         }
         if (added) {
             incActivePuppet().parameters ~= self;

--- a/source/creator/actions/parameter.d
+++ b/source/creator/actions/parameter.d
@@ -6,6 +6,7 @@ module creator.actions.parameter;
 
 import creator.core.actionstack;
 import creator.actions;
+import creator.ext;
 import creator.actions.binding;
 import creator;
 import inochi2d;
@@ -20,10 +21,16 @@ public:
     Parameter self;
     Driver[] drivers;
     Parameter[]* parentList;
+    ExParameterGroup originalParent;
+    long indexInGroup;
 
     this(Parameter self, Parameter[]* parentList) {
         this.self = self;
         this.parentList = parentList;
+
+        auto exParam = cast(ExParameter)self;
+        originalParent = (exParam !is null)? exParam.getParent(): null;
+        indexInGroup = -1;
 
         // Find drivers
         foreach(ref driver; incActivePuppet().getDrivers()) {
@@ -42,14 +49,26 @@ public:
         }
     }
 
+    import std.stdio;
     /**
         Rollback
     */
     void rollback() {
-        if (!added) 
+        auto newParent = originalParent;
+        auto newIndex = indexInGroup;
+        auto exParam = cast(ExParameter)self;
+        if (exParam !is null) {
+            originalParent = exParam.getParent();
+            indexInGroup = originalParent? originalParent.countUntil(exParam): -1;
+        }
+        if (!added) {
             incActivePuppet().parameters ~= self;
-        else
+            if (exParam !is null)
+                exParam.setParent(newParent);
+        } else {
+
             incActivePuppet().removeParameter(self);
+        }
             
         // Re-apply drivers
         foreach(ref driver; drivers) {
@@ -63,10 +82,20 @@ public:
         Redo
     */
     void redo() {
-        if (added)
+        auto newParent = originalParent;
+        auto newIndex = indexInGroup;
+        auto exParam = cast(ExParameter)self;
+        if (exParam !is null) {
+            originalParent = exParam.getParent();
+            indexInGroup = originalParent? originalParent.countUntil(exParam): -1;
+        }
+        if (added) {
             incActivePuppet().parameters ~= self;
-        else
+            if (exParam !is null)
+                exParam.setParent(newParent);
+        } else {
             incActivePuppet().removeParameter(self);
+        }
             
         // Empty drivers
         foreach(ref driver; drivers) {

--- a/source/creator/core/actionstack.d
+++ b/source/creator/core/actionstack.d
@@ -18,6 +18,10 @@ private {
     size_t maxUndoHistory;
 }
 
+enum ActionStackClear {
+    All, CurrentLevel
+};
+
 /**
     Initialize actions system
 */
@@ -163,9 +167,25 @@ void incActionSetIndex(size_t index) {
 /**
     Clears action history
 */
-void incActionClearHistory() {
-    actions[currentLevel].length = 0;
-    actionPointer[currentLevel] = 0;
+void incActionClearHistory(ActionStackClear target = ActionStackClear.All) {
+    switch (target) {
+    case ActionStackClear.All:
+        currentLevel = 0;
+        actions.length = currentLevel + 1;
+        actionPointer.length = currentLevel + 1;
+        actionIndex.length = currentLevel + 1;
+        currentGroup.length = currentLevel + 1;
+        actions[currentLevel].length = 0;
+        actionPointer[currentLevel] = 0;
+        currentGroup[currentLevel] = null;
+        break;
+    case ActionStackClear.CurrentLevel:
+        actions[currentLevel].length = 0;
+        actionPointer[currentLevel] = 0;
+        currentGroup[currentLevel] = null;
+        break;
+    default:
+    }
 }
 
 /**

--- a/source/creator/ext/param.d
+++ b/source/creator/ext/param.d
@@ -136,6 +136,35 @@ public:
         }
         super.finalize(_puppet);
     }
+
+    /**
+        Clone this parameter
+    */
+    override
+    Parameter dup() {
+        Parameter newParam = new ExParameter(name ~ " (Copy)", isVec2);
+
+        newParam.min = min;
+        newParam.max = max;
+        newParam.axisPoints = axisPoints.dup;
+
+        foreach(binding; bindings) {
+            ParameterBinding newBinding = newParam.createBinding(
+                binding.getNode(),
+                binding.getName(),
+                false
+            );
+            newBinding.interpolateMode = binding.interpolateMode;
+            foreach(x; 0..axisPointCount(0)) {
+                foreach(y; 0..axisPointCount(1)) {
+                    binding.copyKeypointToBinding(vec2u(x, y), newBinding, vec2u(x, y));
+                }
+            }
+            newParam.addBinding(newBinding);
+        }
+
+        return newParam;
+    }
 }
 
 void incRegisterExParameter() {

--- a/source/creator/ext/param.d
+++ b/source/creator/ext/param.d
@@ -79,8 +79,16 @@ public:
         super(name, false); 
         parent = null;
     }
+    this(string name, bool isVec2) { 
+        super(name, isVec2); 
+        parent = null;
+    }
     this(string name, ExParameterGroup parent) { 
         super(name, false); 
+        this.parent = parent;
+    }
+    this(string name, bool isVec2, ExParameterGroup parent) { 
+        super(name, isVec2); 
         this.parent = parent;
     }
     override

--- a/source/creator/panels/actionhistory.d
+++ b/source/creator/panels/actionhistory.d
@@ -54,7 +54,7 @@ protected:
         igSeparator();
         igSpacing();
         if (igButton(__("Clear History"), ImVec2(0, 0))) {
-            incActionClearHistory();
+            incActionClearHistory(ActionStackClear.CurrentLevel);
         }
         igSameLine(0, 0);
 

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -515,13 +515,17 @@ private {
                 action.updateNewState();
                 incActionPush(action);
             } else {
+                incActionPushGroup();
                 foreach(binding; bindings) {
                     if (binding.getTarget() in cClipboardBindings) {
                         auto action = new ParameterChangeBindingsValueAction("paste", param, bindings, cParamPoint.x, cParamPoint.y);
                         ParameterBinding origBinding = cClipboardBindings[binding.getTarget()];
                         origBinding.copyKeypointToBinding(cClipboardPoint, binding, cParamPoint);
+                        action.updateNewState();
+                        incActionPush(action);
                     }
                 }
+                incActionPopGroup();
             }
         }
 

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -982,6 +982,9 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
                         if (igMenuItem(__("Duplicate"), "", false, true)) {
                             Parameter newParam = param.dup;
                             incActivePuppet().parameters ~= newParam;
+                            if (auto exParam = cast(ExParameter)newParam) {
+                                exParam.setParent((cast(ExParameter)param).getParent());
+                            }
                             incActionPush(new ParameterAddAction(newParam, &paramArr));
                         }
 

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -332,7 +332,7 @@ private {
     void convertTo2D(Parameter param) {
         auto action = new GroupAction();
 
-        Parameter newParam = new Parameter(param.name, true);
+        auto newParam = new ExParameter(param.name, true);
         newParam.uuid = param.uuid;
         newParam.min  = vec2(param.min.x, param.min.x);
         newParam.max  = vec2(param.max.x, param.max.x);
@@ -356,17 +356,10 @@ private {
             action.addAction(new ParameterRemoveAction(param, &incActivePuppet().parameters));
             action.addAction(new ParameterAddAction(newParam, &incActivePuppet().parameters));
             incActivePuppet().parameters[index] = newParam;
-        } else {
-            foreach (idx, xparam; incActivePuppet().parameters) {
-                if (auto group = cast(ExParameterGroup)xparam) {
-                    index = group.children.countUntil(param);
-                    if (index >= 0) {
-                        action.addAction(new ParameterRemoveAction(param, &group.children));
-                        action.addAction(new ParameterAddAction(newParam, &group.children));
-                        group.children[index] = newParam;
-                        break;
-                    }
-                }
+            if (auto prevParam = cast(ExParameter)param) {
+                auto parent = prevParam.getParent();
+                prevParam.setParent(null);
+                newParam.setParent(parent);
             }
         }
         incActionPush(action);
@@ -996,8 +989,8 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
                             if (incArmedParameter() == param) {
                                 incDisarmParameter();
                             }
-                            incActivePuppet().removeParameter(param);
                             incActionPush(new ParameterRemoveAction(param, &paramArr));
+                            incActivePuppet().removeParameter(param);
                         }
 
                         igNewLine();

--- a/source/creator/viewport/common/mesheditor/package.d
+++ b/source/creator/viewport/common/mesheditor/package.d
@@ -64,6 +64,7 @@ public:
         if (deformOnly) 
             subEditor = new IncMeshEditorOneDrawableDeform();
         else {
+            incActionPushStack();
             subEditor = new IncMeshEditorOneDrawableVertex();
             if (auto drawable = cast(Drawable)target) {
                 if (drawable.getMesh().isGrid()) {
@@ -90,8 +91,10 @@ public:
                 if (drawable) {
                     if (deformOnly)
                         subEditor = new IncMeshEditorOneDrawableDeform();
-                    else
+                    else {
+                        incActionPushStack();
                         subEditor = new IncMeshEditorOneDrawableVertex();
+                    }
                     (cast(IncMeshEditorOneDrawable)subEditor).setTarget(drawable);
                 } else {
                     subEditor = new IncMeshEditorOneNode(deformOnly);

--- a/source/creator/viewport/vertex/package.d
+++ b/source/creator/viewport/vertex/package.d
@@ -11,6 +11,7 @@ import creator.viewport.common.mesh;
 import creator.viewport.common.mesheditor;
 import creator.viewport.common.automesh;
 import creator.core.input;
+import creator.core.actionstack;
 import creator.widgets;
 import creator;
 import inochi2d;
@@ -178,7 +179,7 @@ void incViewportVertexConfirmBar() {
             } else {
                 incMeshEditClear();
             }
-
+            incActionPopStack();
             incSetEditMode(EditMode.ModelEdit);
             foreach (d; target) {
                 incAddSelectNode(d);
@@ -306,6 +307,7 @@ void incMeshEditApply() {
         }
     }
 
+    incActionPopStack();
     // Apply to target
     editor.applyToTarget();
 


### PR DESCRIPTION
https://github.com/Inochi2D/inochi-creator/issues/109
Node Add/Remove action remembers group information and restore the group on undo/redo.
This also fixed potential problem for "To 2D" command, which cannot handle group properly.
And also fixed "Duplicate" operation for parameter, which currently ignores the group information. With this patch, "Duplicate" operation create parameter under the same parameter group.

https://github.com/Inochi2D/inochi-creator/issues/233
Action stack is enhanced, and have multiple undo/redo stack. New stack can be pushed by incActionPushStack and popped by incActionPopStack.
"Edit Mesh" uses another stack from main undo history, and its history is removed when "Apply" or "Cancel" is selected.

https://github.com/Inochi2D/inochi-creator/issues/236
"Paste" command cannot handle undo if more than two bindings are existing at copied key point. This patch fixes wrong handling of undo.