### PR TITLE
Add tracking binding ui

### DIFF
--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -909,6 +909,20 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
                             incPushWindowList(new ParamAxesWindow(param));
                         }
                         
+                        if(param.isVec2) {
+                            if (igMenuItem(__("Set Tracking Binding (X)"), "", false, true)) {
+                                incPushWindowList(new TrackBindingWindow(param, 0));
+                            }
+                            if (igMenuItem(__("Set Tracking Binding (Y)"), "", false, true)) {
+                                incPushWindowList(new TrackBindingWindow(param, 1));
+                            }
+                        }
+                        else {
+                            if (igMenuItem(__("Set Tracking Binding"), "", false, true)) {
+                                incPushWindowList(new TrackBindingWindow(param));
+                            }
+                        }
+                        
                         if (igMenuItem(__("Split"), "", false, true)) {
                             incPushWindowList(new ParamSplitWindow(idx, param));
                         }

--- a/source/creator/tracking/expr.d
+++ b/source/creator/tracking/expr.d
@@ -1,0 +1,73 @@
+/*
+    Copyright © 2022, Inochi2D Project
+    Distributed under the 2-Clause BSD License, see LICENSE file.
+    
+    Authors: Luna Nielsen
+*/
+module creator.tracking.expr;
+import creator.tracking;
+import ft;
+import inochi2d;
+import std.format;
+import i18n;
+import inmath.noise;
+import std.random : uniform;
+
+
+struct Expression {
+private:
+    // expression function name
+    string exprName_;
+
+    // source
+    string expressionSource_;
+
+    // last error
+    string lastError_;
+
+public:
+
+    /**
+        Constructs an expression
+    */
+    this(string signature, string source) {
+        this.exprName_ = signature;
+        this.expressionSource_ = source;
+    }
+
+    this(uint uuid, uint axis, string source) {
+        this.exprName_ = "p%s_%s".format(uuid, axis);
+        this.expressionSource_ = source;
+    }
+
+    /**
+        Gets the expression to evaluate
+    */
+    string signature() {
+        return exprName_;
+    }
+
+    /**
+        Gets the expression to evaluate
+    */
+    string expression() {
+        return expressionSource_;
+    }
+
+    /**
+        Sets the expression to evaluate
+    */
+    bool expression(string value) {
+        expressionSource_ = value;
+        // hack
+        return true;
+    }
+
+    /**
+        Gets the last error encounted for the expression
+    */
+    string lastError() {
+        return lastError_;
+    }
+
+}

--- a/source/creator/tracking/package.d
+++ b/source/creator/tracking/package.d
@@ -1,0 +1,273 @@
+/*
+    Copyright © 2022, Inochi2D Project
+    Distributed under the 2-Clause BSD License, see LICENSE file.
+    
+    Authors: Luna Nielsen
+*/
+module creator.tracking;
+import creator.tracking.expr;
+import inochi2d;
+import inochi2d.math.serialization;
+import fghj;
+import i18n;
+import std.format;
+import std.math.rounding : quantize;
+import std.math : isFinite;
+
+/**
+    Binding Type
+*/
+enum BindingType {
+    /**
+        A binding where the base source is blended via
+        in/out ratios
+    */
+    RatioBinding,
+
+    /**
+        A binding in which math expressions are used to
+        blend between the sources in the VirtualSpace zone.
+    */
+    ExpressionBinding,
+
+    /**
+        Binding controlled from an external source.
+        Eg. over the internet or from a plugin.
+    */
+    External
+}
+
+/**
+    Source type
+*/
+enum SourceType {
+    /**
+        The source is a blendshape
+    */
+    Blendshape,
+
+    /**
+        Source is the X position of a bone
+    */
+    BonePosX,
+
+    /**
+        Source is the Y position of a bone
+    */
+    BonePosY,
+
+    /**
+        Source is the Y position of a bone
+    */
+    BonePosZ,
+
+    /**
+        Source is the roll of a bone
+    */
+    BoneRotRoll,
+
+    /**
+        Source is the pitch of a bone
+    */
+    BoneRotPitch,
+
+    /**
+        Source is the yaw of a bone
+    */
+    BoneRotYaw,
+}
+
+/**
+    Tracking Binding 
+*/
+class TrackingBinding {
+private:
+    // UUID of param to map to
+    uint paramUUID;
+
+    // Sum of weighted plugin values
+    float sum = 0;
+
+    // Combined value of weights
+    float weights = 0;
+
+public:
+    /**
+        Display name for the binding
+    */
+    string name;
+
+    /**
+        Name of the source blendshape or bone
+    */
+    string sourceName;
+
+    /**
+        Display Name of the source blendshape or bone
+    */
+    string sourceDisplayName;
+
+    /**
+        The type of the binding
+    */
+    BindingType type;
+
+    /**
+        The type of the tracking source
+    */
+    SourceType sourceType;
+
+    /**
+        The Inochi2D parameter it should apply to
+    */
+    Parameter param;
+
+    /**
+        Expression (if in ExpressionBinding mode)
+    */
+    Expression* expr;
+
+    /// Ratio for input
+    vec2 inRange = vec2(0, 1);
+
+    /// Ratio for output
+    vec2 outRange = vec2(0, 1);
+
+    /// Last input value
+    float inVal = 0;
+
+    /// Last output value
+    float outVal = 0;
+
+    /**
+        Weights the user has set for each plugin
+    */
+    float[string] pluginWeights;
+
+    /**
+        The axis to apply the binding to
+    */
+    int axis = 0;
+
+    /**
+        Dampening level
+    */
+    int dampenLevel = 0;
+
+    /**
+        Whether to inverse the binding
+    */
+    bool inverse;
+
+    void serialize(S)(ref S serializer) {
+        auto state = serializer.objectBegin;
+            serializer.putKey("name");
+            serializer.putValue(name);
+            serializer.putKey("sourceName");
+            serializer.putValue(sourceName);
+            serializer.putKey("sourceDisplayName");
+            serializer.putValue(sourceDisplayName);
+            serializer.putKey("sourceType");
+            serializer.serializeValue(sourceType);
+            serializer.putKey("bindingType");
+            serializer.serializeValue(type);
+            serializer.putKey("param");
+            serializer.serializeValue(param.uuid);
+            serializer.putKey("axis");
+            serializer.putValue(axis);
+            serializer.putKey("dampenLevel");
+            serializer.putValue(dampenLevel);
+
+            switch(type) {
+                case BindingType.RatioBinding:
+                    serializer.putKey("inverse");
+                    serializer.putValue(inverse);
+
+                    serializer.putKey("inRange");
+                    inRange.serialize(serializer);
+                    serializer.putKey("outRange");
+                    outRange.serialize(serializer);
+                    break;
+                case BindingType.ExpressionBinding:
+                    serializer.putKey("expression");
+                    serializer.putValue(expr.expression());
+                    break;
+                default: break;
+            }
+
+        serializer.objectEnd(state);
+    }
+    
+    SerdeException deserializeFromFghj(Fghj data) {
+        data["name"].deserializeValue(name);
+        data["sourceName"].deserializeValue(sourceName);
+        data["sourceType"].deserializeValue(sourceType);
+        data["bindingType"].deserializeValue(type);
+        data["param"].deserializeValue(paramUUID);
+        if (!data["axis"].isEmpty) data["axis"].deserializeValue(axis);
+        if (!data["dampenLevel"].isEmpty) data["dampenLevel"].deserializeValue(dampenLevel);
+
+        switch(type) {
+            case BindingType.RatioBinding:
+                data["inverse"].deserializeValue(inverse);
+                inRange.deserialize(data["inRange"]);
+                outRange.deserialize(data["outRange"]);
+                break;
+            case BindingType.ExpressionBinding:
+                string exprStr;
+                data["expression"].deserializeValue(exprStr);
+                expr = new Expression(cast(int)this.hashOf(), axis, exprStr);
+                break;
+            default: break;
+        }
+        
+        this.createSourceDisplayName();
+        
+        return null;
+    }
+
+    /**
+        Sets the parameter out range to the default for the axis
+    */
+    void outRangeToDefault() {
+        outRange = vec2(param.min.vector[axis], param.max.vector[axis]);
+    }
+
+    /**
+        Finalizes the tracking binding, if possible.
+        Returns true on success.
+        Returns false if the parameter does not exist.
+    */
+    bool finalize(ref Puppet puppet) {
+        param = puppet.findParameter(paramUUID);
+        return param !is null;
+    }
+
+    void createSourceDisplayName() {
+        switch(sourceType) {
+            case SourceType.Blendshape:
+                sourceDisplayName = sourceName;
+                break;
+            case SourceType.BonePosX:
+                sourceDisplayName = _("%s (X)").format(sourceName);
+                break;
+            case SourceType.BonePosY:
+                sourceDisplayName = _("%s (Y)").format(sourceName);
+                break;
+            case SourceType.BonePosZ:
+                sourceDisplayName = _("%s (Z)").format(sourceName);
+                break;
+            case SourceType.BoneRotRoll:
+                sourceDisplayName = _("%s (Roll)").format(sourceName);
+                break;
+            case SourceType.BoneRotPitch:
+                sourceDisplayName = _("%s (Pitch)").format(sourceName);
+                break;
+            case SourceType.BoneRotYaw:
+                sourceDisplayName = _("%s (Yaw)").format(sourceName);
+                break;
+            default: assert(0);    
+        }
+    }
+}
+

--- a/source/creator/widgets/mainmenu.d
+++ b/source/creator/widgets/mainmenu.d
@@ -443,8 +443,7 @@ void incMainMenu() {
                         if (string path = incShowImportDialog(filters, _("Import..."))) {
                             Puppet p = inLoadPuppet(path);
 
-                            if ("com.inochi2d.inochi-session.bindings" in p.extData) {
-                                incActivePuppet().extData["com.inochi2d.inochi-session.bindings"] = p.extData["com.inochi2d.inochi-session.bindings"].dup;
+                            if (incActiveProject().mergeBindings(p)) {
                                 incSetStatus(_("Successfully overwrote Inochi Session tracking data..."));
                             } else {
                                 incDialog(__("Error"), _("There was no Inochi Session data to import!"));

--- a/source/creator/windows/inpexport.d
+++ b/source/creator/windows/inpexport.d
@@ -282,6 +282,9 @@ protected:
 
             if (igButton(__("Export"), ImVec2(64, 24))) {
                 try {
+                    // Apply bindings before saving
+                    incActiveProject().applyBindings();
+
                     // Write the puppet to file
                     incExportINP(incActivePuppet(), generateAtlasses(), outFile);
                     incSetStatus(_("%s was exported...".format(outFile)));

--- a/source/creator/windows/package.d
+++ b/source/creator/windows/package.d
@@ -18,6 +18,7 @@ public import creator.windows.texviewer;
 public import creator.windows.paramprop;
 public import creator.windows.paramaxes;
 public import creator.windows.paramsplit;
+public import creator.windows.trackbind;
 public import creator.windows.trkbind;
 public import creator.windows.psdmerge;
 public import creator.windows.welcome;

--- a/source/creator/windows/trackbind.d
+++ b/source/creator/windows/trackbind.d
@@ -1,0 +1,266 @@
+/*
+    Copyright © 2020-2023, Inochi2D Project
+    Distributed under the 2-Clause BSD License, see LICENSE file.
+    
+    Authors: Grillo del Mal
+*/
+module creator.windows.trackbind;
+
+import creator.windows;
+import creator.widgets;
+import creator.tracking;
+import creator.tracking.expr;
+import creator;
+import i18n;
+import inochi2d;
+import std.format;
+
+class TrackBindingWindow : Window {
+private:
+    Parameter param;
+    uint axis;
+
+    TrackingBinding binding;
+
+    BindingType bindingType;
+    string sourceName;
+    SourceType sourceType;
+    string expressionFormula;
+    vec2 inRange = vec2(0, 1);
+    vec2 outRange = vec2(0, 1);
+
+    const(char)*[BindingType] bindingTypeComboText;
+    const(char)*[SourceType] sourceTypeComboText;
+    BindingType[] bindingTypeSort = [
+            BindingType.RatioBinding,
+            BindingType.ExpressionBinding,
+            ];
+    SourceType[] sourceTypeSort = [
+            SourceType.Blendshape,
+            SourceType.BonePosX,
+            SourceType.BonePosY,
+            SourceType.BonePosZ,
+            SourceType.BoneRotRoll,
+            SourceType.BoneRotPitch,
+            SourceType.BoneRotYaw,
+        ];
+
+protected:
+    override
+    void onBeginUpdate() {
+        igSetNextWindowSize(ImVec2(200*2, 140*2), ImGuiCond.Appearing);
+        igSetNextWindowSizeConstraints(ImVec2(200*2, 140*2), ImVec2(200*2, 140*2));
+        super.onBeginUpdate();
+    }
+
+    override
+    void onUpdate() {
+        igPushID(cast(void*)param);
+
+        incText(_("Binding Type"));
+        igIndent();
+            if (igBeginCombo("###BindingType", bindingTypeComboText[bindingType])) {
+                foreach(k; bindingTypeSort){
+                    const(char)* name = bindingTypeComboText[k];
+                    if (igSelectable(name, bindingType == k)) {
+                        bindingType = k;
+                    }
+                }
+                igEndCombo();
+            }
+        igUnindent();
+
+        switch(bindingType) {
+            case BindingType.RatioBinding:
+                incText(_("Source name"));
+                igIndent();
+                    incInputText("###SourceName", 150, sourceName);
+                igUnindent();
+
+                incText(_("Source Type"));
+                igIndent();
+                    if (igBeginCombo("###SourceType", sourceTypeComboText[sourceType])) {
+                        foreach(k; sourceTypeSort){
+                            const(char)* name = sourceTypeComboText[k];
+                            if (igSelectable(name, sourceType == k)) {
+                                sourceType = k;
+                                switch(sourceType) {
+                                    case SourceType.Blendshape:
+                                        inRange.x = 0;
+                                        inRange.y = 1;
+                                        break;
+
+                                    case SourceType.BonePosX:
+                                    case SourceType.BonePosY:
+                                    case SourceType.BonePosZ:
+                                        inRange.x = -1;
+                                        inRange.y = 1;
+                                        break;
+                                    case SourceType.BoneRotPitch:
+                                    case SourceType.BoneRotRoll:
+                                    case SourceType.BoneRotYaw:
+                                        inRange.x = -45;
+                                        inRange.y = 45;
+                                        break;
+                                        
+                                    default: assert(0);
+                                }
+
+                            }
+                        }
+                        igEndCombo();
+                    }
+                igUnindent();
+
+                incText(_("Tracking In"));
+                igIndent();
+                    switch(sourceType) {
+                        case SourceType.Blendshape:
+                            igDragFloatRange2(
+                                "###TrackingInBlendshape", 
+                                &(inRange.vector[0]), &(inRange.vector[1]), 0.1f, 
+                                -1, 1);
+                            break;
+
+                        case SourceType.BonePosX:
+                        case SourceType.BonePosY:
+                        case SourceType.BonePosZ:
+                            igDragFloatRange2(
+                                "###TrackingInBonePos", 
+                                &(inRange.vector[0]), &(inRange.vector[1]), 1.0f, 
+                                -float.max, float.max);
+                            break;
+
+                        case SourceType.BoneRotPitch:
+                        case SourceType.BoneRotRoll:
+                        case SourceType.BoneRotYaw:
+                            igDragFloatRange2(
+                                "###TrackingInBoneRot", 
+                                &(inRange.vector[0]), &(inRange.vector[1]), 1.0f, 
+                                -180, 180);
+                            break;
+                            
+                        default: assert(0);
+                    }
+                igUnindent();
+
+                incText(_("Tracking Out"));
+                igIndent();
+                    igDragFloatRange2(
+                        "###TO", 
+                        &(outRange.vector[0]), &(outRange.vector[1]), 1.0f, 
+                        -float.max, float.max);
+                igUnindent();
+                break;
+
+            case BindingType.ExpressionBinding:
+                //Add expresion formula input
+                incText(_("Expresion forumla"));
+                igIndent();
+                    incInputText(_("Expresion formula"), expressionFormula);
+                igUnindent();
+                break;
+
+            default: assert(0);
+        }
+
+        if (igBeginChild("###SettingsBtns", ImVec2(0, 0))) {
+            //if (igButton(__("Refresh Bindable"), ImVec2(0, 24))) {
+                // TODO: Implement on tracking mode
+                //this.currBindable = incViewportTestGetCurrBindable();
+            //}
+
+            igSameLine(0, 0);
+            incDummy(ImVec2(-130, 0));
+            igSameLine(0, 0);
+
+            const(char)* cancelBtnTxt = this.binding !is null ? __("Remove") : __("Cancel");
+            if (igButton(cancelBtnTxt, ImVec2(64, 24))) {
+                if(this.binding !is null) {
+                    incActiveProject().removeBinding(this.binding);
+                }
+                this.close();
+            }
+
+            igSameLine(0, 0);
+            incDummy(ImVec2(-64, 0));
+            igSameLine(0, 0);
+
+            bool canSave = (
+                bindingType == BindingType.RatioBinding && sourceName.length > 0
+                ) || (
+                bindingType == BindingType.ExpressionBinding && expressionFormula.length > 0
+                );
+            if (!canSave) igBeginDisabled();
+                if (igButton(__("Save"), ImVec2(64, 24))) {
+                    TrackingBinding saveBind = this.binding;
+                    if(saveBind is null) {
+                        saveBind = new TrackingBinding();
+                        saveBind.param = param;
+                        saveBind.axis = axis;
+                        saveBind.name = param.isVec2 ? (
+                            "%s (%s)".format(
+                                param.name, axis == 0 ? "X" : "Y")
+                            ) : param.name;
+                        incActiveProject().addBinding(saveBind);
+                    }
+
+                    saveBind.type = this.bindingType;
+                    saveBind.sourceName = this.sourceName;
+                    saveBind.sourceType = this.sourceType;
+                    if(this.bindingType == BindingType.ExpressionBinding) {
+                        saveBind.expr = new Expression(
+                            cast(int)saveBind.hashOf(), axis, 
+                            expressionFormula);
+                    }
+                    saveBind.inRange = this.inRange;
+                    saveBind.outRange = this.outRange;
+
+                    saveBind.createSourceDisplayName();
+
+                    this.close();
+                }
+            if (!canSave) igEndDisabled();
+        }
+        igEndChild();
+
+        igPopID();
+    }
+
+public:
+    this(ref Parameter param, uint axis = 0) {
+        bindingTypeComboText = [
+            BindingType.RatioBinding: __("Ratio Binding"),
+            BindingType.ExpressionBinding: __("Expresion Binding"),
+            //BindingType.External: __("External"),
+        ];
+
+        sourceTypeComboText = [
+            SourceType.Blendshape: __("Blendshape"),
+            SourceType.BonePosX: __("Bone Position (X)"),
+            SourceType.BonePosY: __("Bone Position (Y)"),
+            SourceType.BonePosZ: __("Bone Position (Z)"),
+            SourceType.BoneRotRoll: __("Bone Rotation (Roll)"),
+            SourceType.BoneRotPitch: __("Bone Rotation (Pitch)"),
+            SourceType.BoneRotYaw: __("Bone Rotation (Yaw)"),
+        ];
+
+        this.param = param;
+        this.axis = param.isVec2 ? axis : 0;
+
+        binding = incActiveProject().findBindingByParam(this.param, this.axis);
+        if(this.binding !is null) {
+            this.bindingType = binding.type;
+            this.sourceName = binding.sourceName;
+            this.sourceType = binding.sourceType;
+            this.expressionFormula = binding.expr !is null ? binding.expr.expression : "";
+            this.inRange = binding.inRange;
+            this.outRange = binding.outRange;
+        }
+        super(_("Set Tracking Binding - %s").format(
+            param.isVec2 ? (
+                "%s (%s)".format(
+                    param.name, axis == 0 ? "X" : "Y")
+                ) : param.name));
+    }
+}


### PR DESCRIPTION
This PR adds the option to add/modify/remove arbitrary tracking bindings to parameters on creator (copied some source from session).

![image](https://user-images.githubusercontent.com/11585030/232651362-9beb44c3-c8cd-48c7-a3a6-879bbe02148a.png)

![image](https://user-images.githubusercontent.com/11585030/232651457-8eab80d6-81e4-4157-80be-d3236f0230b9.png)

I made this because this is an useful functionality for me and I wanted to learn how imgui works :yum:

Don't know if this is useful considering the plans to make libsession, but if it can be merged with some changes i'll work on them, I don't mind if it's discarded or used for reference later if it's needed ;).