### PR TITLE
Stop setting the icon on X11

### DIFF
--- a/source/creator/core/package.d
+++ b/source/creator/core/package.d
@@ -324,13 +324,6 @@ void incOpenWindow() {
         inTexPremultiply(tex.data);
         incLogo = new Texture(tex);
 
-        // Set X11 window icon
-        version(linux) {
-            if (!isWayland) {
-                SDL_SetWindowIcon(window, SDL_CreateRGBSurfaceWithFormatFrom(tex.data.ptr, tex.width, tex.height, 32, 4*tex.width,  SDL_PIXELFORMAT_RGBA32));
-            }
-        }
-
         tex = ShallowTexture(cast(ubyte[])import("ui/ui-ada.png"));
         inTexPremultiply(tex.data);
         incAda = new Texture(tex);


### PR DESCRIPTION
We only support flatpak, which has the desktopfile and logo in the package and uses that for the icon; we have little to no reason to set it manually.

