### PR TITLE
OCI flatpak hosting

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -335,3 +335,99 @@ jobs:
         files: |
           ${{ env.FLATPAK_BUNDLE }}.flatpak
 
+  #TODO: Setup result packages and index repository
+  publish-flatpak-oci:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-flatpak
+
+    env:
+      APP_ID: com.inochi2d.inochi-creator
+      FLATPAK_BUNDLE: inochi-creator
+      FLATPAK_BRANCH: nightly
+      #FIXME: Set this to the repository
+      INDEX_GITHUB_USERNAME: 
+      INDEX_REPOSITORY_NAME: 
+      FLATPAK_BUILD_REPO: build-repo
+
+    steps:
+    - name: "Check if Auth Token exists"
+      id: check-token 
+      env: 
+          secret_token: ${{ secrets.PAT }}
+      if: ${{ env.secret_token != '' }}
+      run: |
+        echo "has-token=true" >> $GITHUB_OUTPUT
+
+    - if: steps.check-token.outputs.has-token
+      uses: actions/checkout@v2
+
+    - name: Install flatpak and libcontainers tools
+      if: steps.check-token.outputs.has-token
+      run: |
+        set -e
+        . /etc/os-release
+        sudo apt install -y skopeo flatpak jq
+
+    - name: Download flatpak repo
+      if: steps.check-token.outputs.has-token
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.FLATPAK_BUILD_REPO }}
+
+    - name: Create OCI bundle
+      if: steps.check-token.outputs.has-token
+      run: |
+        set -e
+        mkdir -p ${FLATPAK_BUILD_REPO}/{extensions,refs/{mirrors,remotes},state,tmp/cache}
+        flatpak build-bundle \
+          --oci \
+          --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+          ${FLATPAK_BUILD_REPO} ${FLATPAK_BUNDLE} ${APP_ID} ${FLATPAK_BRANCH}
+
+    - name: Publish OCI image
+      if: steps.check-token.outputs.has-token
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+        REGISTRY_AUTH_FILE: /tmp/auth.json
+      run: |
+        export IMAGE_REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')
+        set -e
+        skopeo login --username "${{ github.actor }}" --password-stdin ghcr.io <<<$GITHUB_TOKEN
+        skopeo copy \
+          oci:${FLATPAK_BUNDLE} \
+          docker://ghcr.io/${IMAGE_REPOSITORY}:$FLATPAK_BRANCH
+
+    - name: Update static index
+      if: steps.check-token.outputs.has-token
+      env:
+        REGISTRY_AUTH_FILE: /tmp/auth.json
+      run: |
+        export IMAGE_REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')
+        export DOCKER="$(skopeo inspect docker://ghcr.io/$IMAGE_REPOSITORY:$FLATPAK_BRANCH | jq --arg github_repository "$GITHUB_REPOSITORY" '. as $img | { "Name": $github_repository, "Images": [$img] }')"
+        set -e
+        git clone -b gh-pages https://github.com/$INDEX_GITHUB_USERNAME/$INDEX_REPOSITORY_NAME.git gh-pages
+        echo '{"Registry": "https://ghcr.io/","Results": []}' | jq --argjson docker "$DOCKER" '.Results += [ $docker ]' > ./gh-pages/index/static
+
+    - name: Check for changes
+      if: steps.check-token.outputs.has-token
+      id: is-updated 
+      run: |
+        set -x
+        git -C ./gh-pages status -s -uno
+        cat gh-pages/index/static
+        # Don't let the file be empty
+        [ ! -s ./gh-pages/index/static ] || [ -z "$(git -C ./gh-pages status -s -uno)" ] || echo "updated=true" >> $GITHUB_OUTPUT
+
+    - name: Push to repository
+      if: steps.is-updated.outputs.updated
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.PAT }}
+      with:
+        source-directory: 'gh-pages'
+        destination-github-username: ${{ env.INDEX_GITHUB_USERNAME }}
+        destination-repository-name: ${{ env.INDEX_REPOSITORY_NAME }}
+        user-email: github-actions[bot]@users.noreply.github.com
+        commit-message: Update index
+        target-branch: gh-pages


### PR DESCRIPTION
:warning: WARNING: This requires some setup before merging, so deal with this when you have time for it :warning:

This adds an extra step to the nightly build script that: 
* Publishes the nightly flatpak as an oci-container through github packages
* Updates a github-pages branch somewhere that is used as an index of the latest available package.

This enables users to automatically get nightly updates by registering the index url
```
flatpak remote-add inochi-creator-nightly oci+https://<user/org>.github.io/<index repo>
flatpak install inochi-creator-nightly com.inochi2d.inochi-creator
```
I have an example one running on `https://github.com/grillo-delmal/inochi-creator-nightly` if you want to check how it works

This sounds nice, but besides merging this, there are other tasks needed for this to work:
* A repository with a gh-pages branch that will function as an index
* Edit the `INDEX_GITHUB_USERNAME` and `INDEX_REPOSITORY_NAME` env variables to point them to the ones with the gh-pages repo. 
* Add a <secret token> with the proper permissions for the workflow to be able to push to another repo/push new packages
* Make packages visible to public (just need to do this once the first package is built)

This is based on the [flatpak-remote](https://github.com/TheEvilSkeleton/flatpak-remote/blob/main/README.md#preparing) project, so you can check there if you want to know more about how this works.

Also, they don't mention it, but the token should be created with the folowing permissions:

![image](https://user-images.githubusercontent.com/11585030/237010661-6d1dba6a-e2f1-4319-af1c-5077be804cd2.png)