### PR TITLE
Fix bug: Avoid crash if trying to remove vertex when mirrored by axes…

### DIFF
--- a/source/creator/viewport/common/mesheditor/tools/point.d
+++ b/source/creator/viewport/common/mesheditor/tools/point.d
@@ -117,7 +117,8 @@ class PointTool : NodeSelect {
                     impl.foreachMirror((uint axis) {
                         ulong index = mesh.getVertexFromPoint(impl.mirror(axis, impl.mousePos));
                         MeshVertex* vertex = impl.getVerticesByIndex([index])[0];
-                        removingVertices ~= vertex;
+                        if (vertex !is null)
+                            removingVertices ~= vertex;
                     });
                     foreach (vertex; removingVertices)
                         action.removeVertex(vertex);


### PR DESCRIPTION
This patch fixed the crash bug which is occurred when rigger tried to remove vertex which has no mirrored point and mirrored edit is turned on.