### PR TITLE
Bug fix + New feature: Undo for Mask addition/removal in order to fix #291

### DIFF
--- a/source/creator/panels/inspector.d
+++ b/source/creator/panels/inspector.d
@@ -902,8 +902,7 @@ void incInspectorModelPart(Part node) {
                         }
 
                         if (igMenuItem(__("Delete"))) {
-                            import std.algorithm.mutation : remove;
-                            node.masks = node.masks.remove(i);
+                            incActionPush(new PartRemoveMaskAction(node.masks[i].maskSrc, node, node.masks[i].mode));
                             igEndPopup();
                             igPopID();
                             igEndListBox();
@@ -959,7 +958,7 @@ void incInspectorModelPart(Part node) {
 
                     // Make sure we don't mask against ourselves as well as don't double mask
                     if (payloadDrawable != node && !node.isMaskedBy(payloadDrawable)) {
-                        node.masks ~= MaskBinding(payloadDrawable.uuid, MaskingMode.Mask, payloadDrawable);
+                        incActionPush(new PartAddMaskAction(payloadDrawable, node, MaskingMode.Mask));
                     }
                 }
             }

--- a/source/creator/viewport/common/mesheditor/tools/point.d
+++ b/source/creator/viewport/common/mesheditor/tools/point.d
@@ -117,7 +117,8 @@ class PointTool : NodeSelect {
                     impl.foreachMirror((uint axis) {
                         ulong index = mesh.getVertexFromPoint(impl.mirror(axis, impl.mousePos));
                         MeshVertex* vertex = impl.getVerticesByIndex([index])[0];
-                        removingVertices ~= vertex;
+                        if (vertex !is null)
+                            removingVertices ~= vertex;
                     });
                     foreach (vertex; removingVertices)
                         action.removeVertex(vertex);


### PR DESCRIPTION
This is a fix for https://github.com/Inochi2D/inochi-creator/issues/291

Application crashed when drawable which is used as mask is deleted.
This patch checks whether drawable is used as mask, and safely remove it from mask configuration.

To restore mask configuration on undo, PartAddRemoveMaskAction is implemented.
As a side effect, Mask addition/removal is handled by undo stack.