### PR TITLE
Bug fix: fix for #297: avoid crash when editing meshgroup in some conditions.

### DIFF
--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -931,7 +931,10 @@ public:
     }
 
     Deformation* deformByDeformationBinding(Drawable part, Deformation deform, bool flipHorz = false) {
-        if (deform.vertexOffsets.length == 0) {
+
+        // Check whether deform has more than 1 triangle.
+        // If not, returns default Deformation which has dummpy offsets.
+        if (deform.vertexOffsets.length < 3) {
             vec2[] vertexOffsets = [];
             for (int i = 0; i < vertices.length; i++)
                 vertexOffsets ~= vec2(0, 0);

--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -931,6 +931,13 @@ public:
     }
 
     Deformation* deformByDeformationBinding(Drawable part, Deformation deform, bool flipHorz = false) {
+        if (deform.vertexOffsets.length == 0) {
+            vec2[] vertexOffsets = [];
+            for (int i = 0; i < vertices.length; i++)
+                vertexOffsets ~= vec2(0, 0);
+            return new Deformation(vertexOffsets);
+        }
+
         auto origVertices = vertices.dup;
 
         // find triangle which covers specified point. 


### PR DESCRIPTION
[#297](https://github.com/Inochi2D/inochi-creator/issues/297) occurred when following conditions are met:
1) Vertices are fully removed in previous edit. (has no vertices.)
2) Mesh are defined and applied
3) MeshGroup has binding for "deform" parameter.

On clicking "Apply", MeshGroup is trying to recalculate the deformation (regardless number of vertices are same or not).
It uses previous deformation as a reference, and assuming deformation has at least three vertices.
But in case MeshGroup has no vertex, it violates the assumptions, and crashed.

This patch simply checks the number of vertices of previous deformation definition, and if length is zero, it simply reset the deformations and return it to caller.