### PR TITLE
Adding tool option buttons for path deformation tool.

### DIFF
--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -261,5 +261,5 @@ public:
     abstract void viewportTools(VertexToolMode mode);
 
     abstract void adjustPathTransform();
-
+    abstract Tool getTool();
 }

--- a/source/creator/viewport/common/mesheditor/operations/impl.d
+++ b/source/creator/viewport/common/mesheditor/operations/impl.d
@@ -129,4 +129,7 @@ public:
         }
     }
 
+    override
+    Tool getTool() { return tools[toolMode]; }
+
 }

--- a/source/creator/viewport/common/mesheditor/package.d
+++ b/source/creator/viewport/common/mesheditor/package.d
@@ -11,6 +11,7 @@ module creator.viewport.common.mesheditor;
 import i18n;
 import creator.viewport;
 public import creator.viewport.common.mesheditor.operations;
+import creator.viewport.common.mesheditor.tools;
 import creator.viewport.common;
 import creator.viewport.common.mesh;
 import creator.viewport.common.spline;
@@ -197,12 +198,14 @@ public:
                     incTooltip(_("Edge Tool"));
                 }
 
-                if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.PathDeform ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
-                    setToolMode(VertexToolMode.PathDeform);
-                    foreach (e; editors)
-                        e.viewportTools(VertexToolMode.PathDeform);
+                if (deformOnly) {
+                    if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.PathDeform ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
+                        setToolMode(VertexToolMode.PathDeform);
+                        foreach (e; editors)
+                            e.viewportTools(VertexToolMode.PathDeform);
+                    }
+                    incTooltip(_("Path Deform Tool"));
                 }
-                incTooltip(_("Path Deform Tool"));
 
                 if (!deformOnly) {
                     if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.Grid ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
@@ -215,6 +218,64 @@ public:
 
             igPopStyleVar(2);
         igSetWindowFontScale(1);
+    }
+
+    void displayToolOptions() {
+        if (this.toolMode == VertexToolMode.PathDeform) {
+            igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0));
+            igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
+            auto deformTool = cast(PathDeformTool)(editors.length == 0 ? null: editors.values()[0].getTool());
+            igBeginGroup();
+                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Define)? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                    foreach (e; editors) {
+                        auto deform = cast(PathDeformTool)(e.getTool());
+                        if (deform !is null)
+                            deform.setMode(PathDeformTool.Mode.Define);
+                    }
+                }
+                incTooltip(_("Define paths"));
+
+                igSameLine(0, 0);
+
+                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Transform) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path deformation
+                    foreach (e; editors) {
+                        auto deform = cast(PathDeformTool)(e.getTool());
+                        if (deform !is null)
+                            deform.setMode(PathDeformTool.Mode.Transform);
+                    }
+                }
+                incTooltip(_("Transform path"));
+            igEndGroup();
+
+            igSameLine(0, 4);
+
+            igBeginGroup();
+                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.getIsRotateMode()) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // rotation mode
+                    foreach (e; editors) {
+                        auto deform = cast(PathDeformTool)(e.getTool());
+                        if (deform !is null)
+                            deform.setIsRotateMode(!deform.getIsRotateMode());
+                    }
+                }
+                incTooltip(_("Set rotation center"));
+            igEndGroup();
+
+            igSameLine(0, 4);
+
+            igBeginGroup();
+                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.getIsShiftMode()) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // move shift
+                    foreach (e; editors) {
+                        auto deform = cast(PathDeformTool)(e.getTool());
+                        if (deform !is null)
+                            deform.setIsShiftMode(!deform.getIsShiftMode());
+                    }
+                }
+                incTooltip(_("Move points along the path"));
+            igEndGroup();
+
+
+            igPopStyleVar(2);
+        }
     }
 
     void setMirrorHoriz(bool mirrorHoriz) {

--- a/source/creator/viewport/model/deform.d
+++ b/source/creator/viewport/model/deform.d
@@ -83,6 +83,12 @@ void incViewportModelDeformTools() {
     }
 }
 
+void incViewportModelDeformOptions() {
+    if (editor) {
+        editor.displayToolOptions();
+    }
+}
+
 void incViewportModelDeformToolSettings() {
 
 }

--- a/source/creator/viewport/model/package.d
+++ b/source/creator/viewport/model/package.d
@@ -209,6 +209,8 @@ void incViewportModelOptions() {
                 incEndDropdownMenu();
             }
             incTooltip(_("Gizmos"));
+        } else {
+            incViewportModelDeformOptions();
         }
     igPopStyleVar(2);
 }


### PR DESCRIPTION
- Added path deform tool options at the top right corner of the viewport.
  - Switching mode (define / transform) for the path deform tool.
  - Adding options to set center point of the rotation.
  - Adding options to toggle shift translation mode.
- Removed path deform tool button in vertex edit mode.