### PR TITLE
Path deformation revise for MeshGroup

### DIFF
--- a/source/creator/actions/mesheditor.d
+++ b/source/creator/actions/mesheditor.d
@@ -343,9 +343,15 @@ public:
     vec3[] newRefOffsets;
     ulong[] oldSelected;
     ulong[] newSelected;
+    vec2[] oldDeformation;
+    vec2[] newDeformation;
     float oldOrigX, oldOrigY, oldOrigRotZ;
     float newOrigX, newOrigY, newOrigRotZ;
     
+    IncMeshEditorOneDrawableDeform selfDeform() {
+        return cast(IncMeshEditorOneDrawableDeform)self();
+    }
+
     auto path() {
         if (self !is null)
             return self.getPath();
@@ -372,8 +378,11 @@ public:
         }
         if (self !is null) {
             oldSelected = self.selected;
+            if (selfDeform !is null)
+                oldDeformation = selfDeform.deformation;
         } else {
             oldSelected = null;
+            oldDeformation = null;
         }
 
         if (this.path && this.path.target !is null)
@@ -395,6 +404,8 @@ public:
         }
         if (self !is null) {
             newSelected = self.selected;
+            if (selfDeform !is null)
+                newDeformation = selfDeform.deformation;
         }
         if (path !is null && path.target !is null) 
             newTargetPathPoints = path.target.points.dup;        
@@ -417,7 +428,11 @@ public:
             oldOrigY = 0;
             oldOrigRotZ = 0;
         }
-        if (self !is null) oldSelected = self.selected;
+        if (self !is null) {
+            oldSelected = self.selected;
+            if (selfDeform !is null)
+                oldDeformation = selfDeform.deformation;
+        }
         else oldSelected = null;
         if (path !is null && path.target !is null)
             oldTargetPathPoints = path.target.points.dup;
@@ -443,7 +458,11 @@ public:
                 path.origRotZ  = oldOrigRotZ;
                 path.update(); /// FIX ME: we need to recreate path object if needed.
             }
-            if (oldSelected !is null) self.selected = oldSelected.dup;
+            if (oldSelected !is null) {
+                self.selected = oldSelected.dup;
+            }
+            if (oldDeformation !is null)
+                selfDeform.deformation = oldDeformation.dup;
             if (oldTargetPathPoints !is null && oldTargetPathPoints.length > 0 && path !is null && path.target !is null) {
                 path.target.points = oldTargetPathPoints.dup;
                 path.target.update(); /// FIX ME: we need to recreate path object if needed.
@@ -467,7 +486,11 @@ public:
                 path.origRotZ  = newOrigRotZ;
                 path.update();
             }
-            if (newSelected !is null) self.selected = newSelected.dup;
+            if (newSelected !is null) {
+                self.selected = newSelected.dup;
+            }
+            if (newDeformation !is null)
+                selfDeform.deformation = newDeformation.dup;
             if (newTargetPathPoints !is null && newTargetPathPoints.length > 0 && path !is null && path.target !is null) {
                 path.target.points = newTargetPathPoints.dup;
                 path.target.update();

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -472,7 +472,6 @@ protected:
     void substituteMeshVertices(MeshVertex* meshVertex) {
     }
     MeshEditorAction!DeformationAction editorAction = null;
-    vec2[] deformation;
     void updateTarget() {
         auto drawable = cast(Drawable)target;
         transform = drawable.getDynamicMatrix();
@@ -483,6 +482,7 @@ protected:
     }
 
 public:
+    vec2[] deformation;
     vec2[] vertices;
 
     this() {

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -623,7 +623,7 @@ public:
 
     override
     void remapPathTarget(ref CatmullSpline p, mat4 trans) {
-        p.remapTarget(mesh, trans); //mat4.identity);
+        p.remapTarget(mesh, trans, vertices); //mat4.identity);
     }
 
     override
@@ -779,12 +779,10 @@ public:
         auto drawable = cast(Drawable)target;
 
         mat4 trans = (target? drawable.getDynamicMatrix(): transform).inverse * transform;
+        deformation = drawable.deformation.dup;
         ref CatmullSpline doAdjust(ref CatmullSpline p) {
-//            for (int i; i < p.points.length; i++) {
-//                p.points[i].position = (trans * vec4(p.points[i].position, 0, 1)).xy;
-//            }
             p.update();
-//            remapPathTarget(p, mat4.identity);
+
             remapPathTarget(p, trans);
             return p;
         }

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -472,7 +472,7 @@ protected:
     void substituteMeshVertices(MeshVertex* meshVertex) {
     }
     MeshEditorAction!DeformationAction editorAction = null;
-
+    vec2[] deformation;
     void updateTarget() {
         auto drawable = cast(Drawable)target;
         transform = drawable.getDynamicMatrix();
@@ -494,6 +494,7 @@ public:
         Drawable drawable = cast(Drawable)target;
         if (drawable is null)
             return;
+        deformation = drawable.deformation.dup;
         super.setTarget(target);
         updateTarget();
         mesh = new IncMesh(drawable.getMesh());
@@ -607,12 +608,12 @@ public:
 
     override
     void createPathTarget() {
-        getPath().createTarget(mesh, mat4.identity); //transform.inverse() * target.transform.matrix);
+        getPath().createTarget(mesh, mat4.identity, vertices); //transform.inverse() * target.transform.matrix);
     }
 
     override
     mat4 updatePathTarget() {
-        return getPath().updateTarget(mesh, selected);
+        return getPath().updateTarget(mesh, selected, mat4.identity(), deformation);
     }
 
     override
@@ -622,7 +623,7 @@ public:
 
     override
     void remapPathTarget(ref CatmullSpline p, mat4 trans) {
-        p.remapTarget(mesh, mat4.identity);
+        p.remapTarget(mesh, trans); //mat4.identity);
     }
 
     override
@@ -779,11 +780,12 @@ public:
 
         mat4 trans = (target? drawable.getDynamicMatrix(): transform).inverse * transform;
         ref CatmullSpline doAdjust(ref CatmullSpline p) {
-            for (int i; i < p.points.length; i++) {
-                p.points[i].position = (trans * vec4(p.points[i].position, 0, 1)).xy;
-            }
+//            for (int i; i < p.points.length; i++) {
+//                p.points[i].position = (trans * vec4(p.points[i].position, 0, 1)).xy;
+//            }
             p.update();
-            remapPathTarget(p, mat4.identity);
+//            remapPathTarget(p, mat4.identity);
+            remapPathTarget(p, trans);
             return p;
         }
         if (getPath()) {

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -481,6 +481,23 @@ protected:
         }
     }
 
+    void importDeformation() {
+        Drawable drawable = cast(Drawable)target;
+        if (drawable is null)
+            return;
+        deformation = drawable.deformation.dup;
+        auto param = incArmedParameter();
+        auto binding = cast(DeformationParameterBinding)param.getBinding(drawable, "deform");
+
+        auto deform = binding.getValue(param.findClosestKeypoint());
+        if (drawable.deformation.length == deform.vertexOffsets.length) {
+            deformation.length = drawable.deformation.length;
+            foreach (i, d; drawable.deformation) {
+                deformation[i] = d - deform.vertexOffsets[i];
+            }
+        }
+    }
+
 public:
     vec2[] deformation;
     vec2[] vertices;
@@ -494,7 +511,7 @@ public:
         Drawable drawable = cast(Drawable)target;
         if (drawable is null)
             return;
-        deformation = drawable.deformation.dup;
+        importDeformation();
         super.setTarget(target);
         updateTarget();
         mesh = new IncMesh(drawable.getMesh());
@@ -779,7 +796,7 @@ public:
         auto drawable = cast(Drawable)target;
 
         mat4 trans = (target? drawable.getDynamicMatrix(): transform).inverse * transform;
-        deformation = drawable.deformation.dup;
+        importDeformation();
         ref CatmullSpline doAdjust(ref CatmullSpline p) {
             p.update();
 

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -487,15 +487,20 @@ protected:
             return;
         deformation = drawable.deformation.dup;
         auto param = incArmedParameter();
-        auto binding = cast(DeformationParameterBinding)param.getBinding(drawable, "deform");
-
-        auto deform = binding.getValue(param.findClosestKeypoint());
-        if (drawable.deformation.length == deform.vertexOffsets.length) {
-            deformation.length = drawable.deformation.length;
-            foreach (i, d; drawable.deformation) {
-                deformation[i] = d - deform.vertexOffsets[i];
+        auto binding = cast(DeformationParameterBinding)(param? param.getBinding(drawable, "deform"): null);
+        if (binding is null) {
+            deformation = drawable.deformation.dup;
+            
+        } else {
+            auto deform = binding.getValue(param.findClosestKeypoint());
+            if (drawable.deformation.length == deform.vertexOffsets.length) {
+                deformation.length = drawable.deformation.length;
+                foreach (i, d; drawable.deformation) {
+                    deformation[i] = d - deform.vertexOffsets[i];
+                }
             }
         }
+            
     }
 
 public:


### PR DESCRIPTION
Updated code of path deformation tool and spline to use vertex position which is deformed by MeshGroup.
This means spline deforms in visible vertex in display, and applied by reverse manner.
This code may have problem when MeshGroup has T/R/S transform definition.

I'd like to ask testers to try and find whether there is any problem in the current implementation.