### PR TITLE
Fix bugs that children of composite node is not displayed on vertex edit mode.

### DIFF
--- a/source/creator/viewport/vertex/package.d
+++ b/source/creator/viewport/vertex/package.d
@@ -205,11 +205,15 @@ void incViewportVertexDraw(Camera camera) {
             } else if (MeshGroup mgroup = cast(MeshGroup)target) {
                 mat4 transform = mgroup.transform.matrix.inverse;
                 mgroup.setOneTimeTransform(&transform);
-                Drawable[] subParts;
+                Node[] subParts;
                 void findSubDrawable(Node n) {
                     if (auto m = cast(MeshGroup)n) {
                         foreach (child; n.children)
                             findSubDrawable(child);
+                    } else if (auto c = cast(Composite)n) {
+                        if (c.propagateMeshGroup) {
+                            subParts ~= c;
+                        }
                     } else if (auto d = cast(Drawable)n) {
                         subParts ~= d;
                         foreach (child; n.children)


### PR DESCRIPTION
Fixed the problem that child of composite node isn't displayed correctly for Vertex Edit view.
This patch fixed the problem.
This patch depends on https://github.com/Inochi2D/inochi2d/pull/55