### PR TITLE
Add node icons to Flip Pairing window

### DIFF
--- a/source/creator/windows/flipconfig.d
+++ b/source/creator/windows/flipconfig.d
@@ -12,6 +12,7 @@ import creator;
 import creator.ext;
 import std.string;
 import creator.utils.link;
+import creator.utils;
 import inochi2d;
 import i18n;
 import psd;
@@ -226,18 +227,18 @@ private:
 
             igPushID(cast(int)i);
 
-            igSelectable(node.cName, false, ImGuiSelectableFlagsI.SpanAvailWidth);
+            igSelectable((incTypeIdToIcon(node.typeId)~node.name).toStringz, false, ImGuiSelectableFlagsI.SpanAvailWidth);
 
             if(igBeginDragDropSource(ImGuiDragDropFlags.SourceAllowNullID)) {
                 igSetDragDropPayload("__PAIRING", cast(void*)&node, (&node).sizeof, ImGuiCond.Always);
-                igText(node.cName);
+                incText(incTypeIdToIcon(node.typeId)~node.name);
                 igEndDragDropSource();
             }
 
             // Incredibly cursed preview image
             if (igIsItemHovered()) {
                 igBeginTooltip();
-                    incText(node.name);
+                    incText(incTypeIdToIcon(node.typeId)~node.name);
                     // Calculate render size
                     if (auto part = cast(Part)node) {
                         previewImage(part, ImVec2(PreviewSize/2, PreviewSize/2), PreviewSize);
@@ -278,7 +279,7 @@ private:
                 igSetItemAllowOverlap();
             igPopStyleColor();
             igSameLine();
-            igText(pair.parts[0].cName);
+            incText(incTypeIdToIcon(pair.parts[0].typeId)~pair.parts[0].name);
             // Only allow reparenting one node
             if(igBeginDragDropTarget()) {
                 const(ImGuiPayload)* payload = igAcceptDragDropPayload("__PAIRING");
@@ -313,7 +314,7 @@ private:
             }
 
             igTableNextColumn();
-            igText(pair.parts[1] ? pair.parts[1].cName : __("<< Not assigned >>"));
+            incText(pair.parts[1] ? (incTypeIdToIcon(pair.parts[1].typeId)~pair.parts[1].name) : _("<< Not assigned >>"));
             // Only allow reparenting one node
             if(igBeginDragDropTarget()) {
                 const(ImGuiPayload)* payload = igAcceptDragDropPayload("__PAIRING");


### PR DESCRIPTION
As the title describes, this PR changes the Flip Pairing window so that it shows the icon corresponding to the node type associated to each node.

This change was made in response to #325, a bug that can be triggered if the user pairs a node with an image and then tries to mirror the image deformation to the node. 

The change won't fix the bug, but it will make it easier to notice the difference between nodes when they share names as it was the case in the bug's reported example.

Before:
![fb_before](https://github.com/Inochi2D/inochi-creator/assets/11585030/0b67f1d9-e573-4365-962f-560322cc3589)

After:
![fp_after](https://github.com/Inochi2D/inochi-creator/assets/11585030/a16a291e-8540-4e03-bcc0-682fc89940a7)