### PR TITLE
Cancel mirror deformation if part's pair is not drawable

### DIFF
--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -98,6 +98,9 @@ private {
             Node target = binding.getTarget().node;
             auto pair = incGetFlipPairFor(target);
             auto targetBinding = incBindingGetPairFor(param, target, pair, binding.getName(), true);
+            // Check if the binding was found or created
+            if(targetBinding is null) continue;
+
             uint xCount = param.axisPointCount(0);
             uint yCount = param.axisPointCount(1);
             foreach(x; 0..xCount) {
@@ -130,6 +133,9 @@ private {
             if (axis != 2)
                 pair = incGetFlipPairFor(target);
             auto binding = incBindingGetPairFor(param, target, pair, srcBinding.getName(), true);
+            // Check if the binding was found or created
+            if(targetBinding is null) continue;
+
             uint xCount = param.axisPointCount(0);
             uint yCount = param.axisPointCount(1);
             foreach(x; 0..xCount) {
@@ -348,7 +354,7 @@ private {
                         auto targetBinding = incBindingGetPairFor(param, target, pair, binding.getName(), targetBindings is null);
                         if (targetBindings !is null)
                             incBindingAutoFlip(binding, targetBinding, cParamPoint, 0);
-                        else
+                        else if(targetBinding !is null)
                             incBindingAutoFlip(targetBinding, binding, cParamPoint, 0);
                     }
                     action.updateNewState();
@@ -365,7 +371,7 @@ private {
                         auto targetBinding = incBindingGetPairFor(param, target, pair, binding.getName(), targetBindings is null);
                         if (targetBindings !is null)
                             incBindingAutoFlip(binding, targetBinding, cParamPoint, 1);
-                        else
+                        else if(targetBinding !is null)
                             incBindingAutoFlip(targetBinding, binding, cParamPoint, 1);
                     }
                     action.updateNewState();
@@ -382,7 +388,7 @@ private {
                         auto targetBinding = incBindingGetPairFor(param, target, pair, binding.getName(), targetBindings is null);
                         if (targetBindings !is null)
                             incBindingAutoFlip(binding, targetBinding, cParamPoint, -1);
-                        else
+                        else if(targetBinding !is null)
                             incBindingAutoFlip(targetBinding, binding, cParamPoint, -1);
                     }
                     action.updateNewState();
@@ -402,7 +408,7 @@ private {
                     auto targetBinding = incBindingGetPairFor(param, target, pair, binding.getName(), targetBindings is null);
                     if (targetBindings !is null)
                         incBindingAutoFlip(binding, targetBinding, cParamPoint, 0);
-                    else
+                    else if(targetBinding !is null)
                         incBindingAutoFlip(targetBinding, binding, cParamPoint, 0);
                 }
                 action.updateNewState();

--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -134,7 +134,7 @@ private {
                 pair = incGetFlipPairFor(target);
             auto binding = incBindingGetPairFor(param, target, pair, srcBinding.getName(), true);
             // Check if the binding was found or created
-            if(targetBinding is null) continue;
+            if(binding is null) continue;
 
             uint xCount = param.axisPointCount(0);
             uint yCount = param.axisPointCount(1);

--- a/source/creator/utils/transform.d
+++ b/source/creator/utils/transform.d
@@ -109,6 +109,8 @@ void incBindingAutoFlip(ParameterBinding binding, ParameterBinding srcBinding, v
     if (srcBinding !is null) {
         if (deformBinding !is null) {
             Drawable drawable = cast(Drawable)deformBinding.getTarget().node;
+            // Exit if it's not drawable
+            if(drawable is null) return;
             auto srcDeformBinding = cast(DeformationParameterBinding)srcBinding;
             Drawable srcDrawable = cast(Drawable)srcDeformBinding.getTarget().node;
             auto mesh = new IncMesh(drawable.getMesh());
@@ -134,6 +136,8 @@ void incBindingAutoFlip(ParameterBinding binding, ParameterBinding srcBinding, v
     } else {
         if (deformBinding !is null) {
             Drawable drawable = cast(Drawable)deformBinding.getTarget().node;
+            // Exit if it's not drawable
+            if(drawable is null) return;
             auto mesh = new IncMesh(drawable.getMesh());
             Deformation deform = extrapolation? extrapolateValueAt!Deformation(deformBinding, index, axis):
                                                 interpolateValueAt!Deformation(deformBinding, index, axis);

--- a/source/creator/utils/transform.d
+++ b/source/creator/utils/transform.d
@@ -40,7 +40,7 @@ ParameterBinding incBindingGetPairFor(Parameter param, Node target, FlipPair pai
     if (forceCreate) {
         result = param.createBinding(pairNode, name);
         // Skip if trying to add a deform binding to a node that can't get deformed
-        if(name == "deform" && cast(Drawable)pairNode is null) return result;
+        if(name == "deform" && cast(Drawable)pairNode is null) return null;
         param.addBinding(result);
         auto action = new ParameterBindingAddAction(param, result);
         incActionPush(action);

--- a/source/creator/utils/transform.d
+++ b/source/creator/utils/transform.d
@@ -39,6 +39,8 @@ ParameterBinding incBindingGetPairFor(Parameter param, Node target, FlipPair pai
     }
     if (forceCreate) {
         result = param.createBinding(pairNode, name);
+        // Skip if trying to add a deform binding to a node that can't get deformed
+        if(name == "deform" && cast(Drawable)pairNode is null) return result;
         param.addBinding(result);
         auto action = new ParameterBindingAddAction(param, result);
         incActionPush(action);

--- a/source/creator/utils/transform.d
+++ b/source/creator/utils/transform.d
@@ -111,7 +111,7 @@ void incBindingAutoFlip(ParameterBinding binding, ParameterBinding srcBinding, v
     if (srcBinding !is null) {
         if (deformBinding !is null) {
             Drawable drawable = cast(Drawable)deformBinding.getTarget().node;
-            // Exit if it's not drawable
+            // Return if target node doesn't support deformations 
             if(drawable is null) return;
             auto srcDeformBinding = cast(DeformationParameterBinding)srcBinding;
             Drawable srcDrawable = cast(Drawable)srcDeformBinding.getTarget().node;
@@ -125,6 +125,8 @@ void incBindingAutoFlip(ParameterBinding binding, ParameterBinding srcBinding, v
 
         } else {
             auto srcValueBinding = cast(ValueParameterBinding)srcBinding;
+            // Return if target binding doesn't support being flipped
+            if(srcValueBinding is null) return;
             float value;
             value = extrapolation? extrapolateValueAt!float(srcValueBinding, index, axis):
                                     interpolateValueAt!float(srcValueBinding, index, axis);
@@ -138,7 +140,7 @@ void incBindingAutoFlip(ParameterBinding binding, ParameterBinding srcBinding, v
     } else {
         if (deformBinding !is null) {
             Drawable drawable = cast(Drawable)deformBinding.getTarget().node;
-            // Exit if it's not drawable
+            // Return if target node doesn't support deformations 
             if(drawable is null) return;
             auto mesh = new IncMesh(drawable.getMesh());
             Deformation deform = extrapolation? extrapolateValueAt!Deformation(deformBinding, index, axis):


### PR DESCRIPTION
This change fixes a crash caused by the "Set from mirror" option when Parts are paired with Nodes in the "Flip Pairing" window and a deformation is tried to be applied to the Node. This is fixed by ignoring deformations if the Node can't get deformed. 

Fixes #325 