### PR TITLE
Brushtool implementation and refactoring on Tool.

### DIFF
--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -12,6 +12,7 @@
 */
 module creator.viewport.common.mesh;
 import creator.viewport;
+import creator.viewport.common.mesheditor.brushes;
 import inochi2d;
 import inochi2d.core.dbg;
 import bindbc.opengl;
@@ -499,11 +500,10 @@ public:
         return -1;
     }
 
-    float[] getVerticesInBrush(vec2 point, float radius) {
+    float[] getVerticesInBrush(vec2 point, Brush brush) {
         float[] indices;
         foreach(idx, ref vert; vertices) {
-            float distance = 1 - abs(vert.position.distance(point)) / radius;
-            indices ~= max(distance, 0);
+            indices ~= brush.weightAt(point, vert.position);
         }
         return indices;
     }

--- a/source/creator/viewport/common/mesh.d
+++ b/source/creator/viewport/common/mesh.d
@@ -499,6 +499,15 @@ public:
         return -1;
     }
 
+    float[] getVerticesInBrush(vec2 point, float radius) {
+        float[] indices;
+        foreach(idx, ref vert; vertices) {
+            float distance = 1 - abs(vert.position.distance(point)) / radius;
+            indices ~= max(distance, 0);
+        }
+        return indices;
+    }
+
     void remove(MeshVertex* vert) {
         import std.algorithm.searching : countUntil;
         import std.algorithm.mutation : remove;

--- a/source/creator/viewport/common/mesheditor/brushes/base.d
+++ b/source/creator/viewport/common/mesheditor/brushes/base.d
@@ -1,0 +1,10 @@
+module creator.viewport.common.mesheditor.brushes.base;
+import inmath;
+
+interface Brush {
+    bool isInside(vec2 center, vec2 pos);
+    float weightAt(vec2 center, vec2 pos);
+    float[] weightsAt(vec2 center, vec2[] positions);
+    void draw(vec2 center, mat4 transform);
+    bool configure();
+}

--- a/source/creator/viewport/common/mesheditor/brushes/base.d
+++ b/source/creator/viewport/common/mesheditor/brushes/base.d
@@ -2,6 +2,7 @@ module creator.viewport.common.mesheditor.brushes.base;
 import inmath;
 
 interface Brush {
+    string name();
     bool isInside(vec2 center, vec2 pos);
     float weightAt(vec2 center, vec2 pos);
     float[] weightsAt(vec2 center, vec2[] positions);

--- a/source/creator/viewport/common/mesheditor/brushes/circlebrush.d
+++ b/source/creator/viewport/common/mesheditor/brushes/circlebrush.d
@@ -1,0 +1,64 @@
+module creator.viewport.common.mesheditor.brushes.circlebrush;
+
+import creator.viewport.common.mesheditor.brushes.base;
+import creator.viewport;
+import creator.widgets.drag;
+import inochi2d;
+import inochi2d.core.dbg;
+import inmath;
+import bindbc.imgui;
+
+class CircleBrush : Brush {
+    float radius;
+    //float ratio;
+    //float angle;
+    
+    this(float radius) {
+        this.radius = radius;
+    }
+    
+    override
+    bool isInside(vec2 center, vec2 pos) {
+        return (center.distance(pos) <= radius);
+    }
+    
+    override
+    float weightAt(vec2 center, vec2 pos) {
+        float distance = 1 - abs(pos.distance(center)) / radius;
+        return min(1, max(distance, 0));
+    }
+
+    override
+    float[] weightsAt(vec2 center, vec2[] positions) {
+        float[] result;
+        foreach (p; positions) {
+            result ~= weightAt(center, p);
+        }
+        return result;
+    }
+    
+    override
+    void draw(vec2 center, mat4 transform) {
+        vec3[] drawPoints;
+        drawPoints ~= vec3(center, 0);
+        inDbgSetBuffer(drawPoints);
+        inDbgPointsSize(radius * incViewportZoom * 2 + 4);
+        inDbgDrawPoints(vec4(0, 0, 0, 0.1), transform);
+        inDbgPointsSize(2 * radius * incViewportZoom);
+        inDbgDrawPoints(vec4(1, 1, 1, 0.3), transform);
+    }
+
+    override
+    bool configure() {
+        igBeginGroup();
+            igPushID("BRUSH_RADIUS");
+            igSetNextItemWidth(64);
+            incDragFloat(
+                "brush_radius", &radius, 1,
+                1, 2000, "%.2f", ImGuiSliderFlags.NoRoundToFormat);
+            igPopID();
+    
+        igEndGroup();
+        return false;
+    }
+}

--- a/source/creator/viewport/common/mesheditor/brushes/circlebrush.d
+++ b/source/creator/viewport/common/mesheditor/brushes/circlebrush.d
@@ -2,6 +2,7 @@ module creator.viewport.common.mesheditor.brushes.circlebrush;
 
 import creator.viewport.common.mesheditor.brushes.base;
 import creator.viewport;
+import creator.viewport.common;
 import creator.widgets.drag;
 import inochi2d;
 import inochi2d.core.dbg;
@@ -42,13 +43,16 @@ class CircleBrush : Brush {
     
     override
     void draw(vec2 center, mat4 transform) {
-        vec3[] drawPoints;
-        drawPoints ~= vec3(center, 0);
+        vec3[] drawPoints = incCreateCircleBuffer(center, vec2(radius, radius), 32);
+        drawPoints ~= vec3(center.x - radius, center.y, 0);
+        drawPoints ~= vec3(center.x + radius, center.y, 0);
+        drawPoints ~= vec3(center.x, center.y - radius, 0);
+        drawPoints ~= vec3(center.x, center.y + radius, 0);
         inDbgSetBuffer(drawPoints);
-        inDbgPointsSize(radius * incViewportZoom * 2 + 4);
-        inDbgDrawPoints(vec4(0, 0, 0, 0.1), transform);
-        inDbgPointsSize(2 * radius * incViewportZoom);
-        inDbgDrawPoints(vec4(1, 1, 1, 0.3), transform);
+        inDbgPointsSize(8);
+        inDbgDrawLines(vec4(0, 0, 0, 1), transform);
+        inDbgPointsSize(4);
+        inDbgDrawLines(vec4(1, 0, 0, 1), transform);
     }
 
     override

--- a/source/creator/viewport/common/mesheditor/brushes/doublethreshbrush.d
+++ b/source/creator/viewport/common/mesheditor/brushes/doublethreshbrush.d
@@ -2,6 +2,7 @@ module creator.viewport.common.mesheditor.brushes.doublethreshbrush;
 
 import creator.viewport.common.mesheditor.brushes.base;
 import creator.viewport;
+import creator.viewport.common;
 import creator.widgets.drag;
 import inochi2d;
 import inochi2d.core.dbg;
@@ -48,15 +49,17 @@ class DoubleThreshBrush : Brush {
     
     override
     void draw(vec2 center, mat4 transform) {
-        vec3[] drawPoints;
-        drawPoints ~= vec3(center, 0);
+        vec3[] drawPoints = incCreateCircleBuffer(center, vec2(radius, radius), 32) ~
+                            incCreateCircleBuffer(center, vec2(innerRadius, innerRadius), 32);
+        drawPoints ~= vec3(center.x - radius, center.y, 0);
+        drawPoints ~= vec3(center.x + radius, center.y, 0);
+        drawPoints ~= vec3(center.x, center.y - radius, 0);
+        drawPoints ~= vec3(center.x, center.y + radius, 0);
         inDbgSetBuffer(drawPoints);
-        inDbgPointsSize(radius * incViewportZoom * 2 + 4);
-        inDbgDrawPoints(vec4(0, 0, 0, 0.1), transform);
-        inDbgPointsSize(2 * radius * incViewportZoom);
-        inDbgDrawPoints(vec4(.5, .5, .5, 0.1), transform);
-        inDbgPointsSize(2 * innerRadius * incViewportZoom);
-        inDbgDrawPoints(vec4(1, 1, 1, 0.2), transform);
+        inDbgPointsSize(8);
+        inDbgDrawLines(vec4(0, 0, 0, 1), transform);
+        inDbgPointsSize(4);
+        inDbgDrawLines(vec4(1, 0, 0, 1), transform);
     }
 
     override

--- a/source/creator/viewport/common/mesheditor/brushes/package.d
+++ b/source/creator/viewport/common/mesheditor/brushes/package.d
@@ -1,0 +1,4 @@
+module creator.viewport.common.mesheditor.brushes;
+
+public import creator.viewport.common.mesheditor.brushes.base;
+public import creator.viewport.common.mesheditor.brushes.circlebrush;

--- a/source/creator/viewport/common/mesheditor/brushes/package.d
+++ b/source/creator/viewport/common/mesheditor/brushes/package.d
@@ -3,6 +3,7 @@ module creator.viewport.common.mesheditor.brushes;
 public import creator.viewport.common.mesheditor.brushes.base;
 public import creator.viewport.common.mesheditor.brushes.circlebrush;
 public import creator.viewport.common.mesheditor.brushes.doublethreshbrush;
+public import creator.viewport.common.mesheditor.brushes.rectanglebrush;
 
 private {
     Brush[] brushes;
@@ -12,6 +13,7 @@ Brush[] incBrushList() {
     if (brushes.length == 0) {
         brushes ~= new CircleBrush("Circle Brush", 300);
         brushes ~= new DoubleThreshBrush("Double Threshold Circle", 300, 100);
+        brushes ~= new RectangleBrush("Rectangle Brush", 300, 300, 0.0);
     }
     return brushes;
 }

--- a/source/creator/viewport/common/mesheditor/brushes/package.d
+++ b/source/creator/viewport/common/mesheditor/brushes/package.d
@@ -2,3 +2,16 @@ module creator.viewport.common.mesheditor.brushes;
 
 public import creator.viewport.common.mesheditor.brushes.base;
 public import creator.viewport.common.mesheditor.brushes.circlebrush;
+public import creator.viewport.common.mesheditor.brushes.doublethreshbrush;
+
+private {
+    Brush[] brushes;
+}
+
+Brush[] incBrushList() {
+    if (brushes.length == 0) {
+        brushes ~= new CircleBrush("Circle Brush", 300);
+        brushes ~= new DoubleThreshBrush("Double Threshold Circle", 300, 100);
+    }
+    return brushes;
+}

--- a/source/creator/viewport/common/mesheditor/brushes/rectanglebrush.d
+++ b/source/creator/viewport/common/mesheditor/brushes/rectanglebrush.d
@@ -1,0 +1,91 @@
+module creator.viewport.common.mesheditor.brushes.rectanglebrush;
+
+import creator.viewport.common.mesheditor.brushes.base;
+import creator.viewport;
+import creator.viewport.common;
+import creator.widgets.drag;
+import inochi2d;
+import inochi2d.core.dbg;
+import inmath;
+import bindbc.imgui;
+
+class RectangleBrush : Brush {
+    float width;
+    float height;
+    float innerRatio;
+    string _name;
+    
+    this(string name, float width, float height, float innerRatio) {
+        _name = name;
+        this.width = max(1, width);
+        this.height = max(1, height);
+        this.innerRatio = max(0, min(innerRatio, 1));
+    }
+
+    override
+    string name() {return _name;}
+    
+    override
+    bool isInside(vec2 center, vec2 pos) {
+        vec2 distance = (pos - center).abs;
+        return distance.x <= width / 2 && distance.y <= height;
+    }
+    
+    override
+    float weightAt(vec2 center, vec2 pos) {
+        vec2 distance = (pos - center).abs;
+        float xratio = min(1, max(0, 1 - distance.x / width));
+        float yratio = min(1, max(0, 1 - distance.y / height));
+        return min(xratio, yratio);
+    }
+
+    override
+    float[] weightsAt(vec2 center, vec2[] positions) {
+        float[] result;
+        foreach (p; positions) {
+            result ~= weightAt(center, p);
+        }
+        return result;
+    }
+    
+    override
+    void draw(vec2 center, mat4 transform) {
+        auto drawPoints = incCreateRectBuffer(vec2(center.x - width, center.y - height), vec2(center.x + width, center.y + height));
+        inDbgSetBuffer(drawPoints);
+        inDbgPointsSize(8);
+        inDbgDrawLines(vec4(0, 0, 0, 1), transform);
+        inDbgPointsSize(4);
+        inDbgDrawLines(vec4(1, 0, 0, 1), transform);
+    }
+
+    override
+    bool configure() {
+        igBeginGroup();
+            igPushID("BRUSH_WIDTH");
+            igSetNextItemWidth(64);
+            incDragFloat(
+                "brush_width", &width, 1,
+                1, 2000, "%.2f", ImGuiSliderFlags.NoRoundToFormat);
+            igPopID();
+
+            igSameLine(0, 4);
+    
+            igPushID("BRUSH_HEIGHT");
+            igSetNextItemWidth(64);
+            incDragFloat(
+                "brush_height", &height, 1,
+                1, 2000, "%.2f", ImGuiSliderFlags.NoRoundToFormat);
+            igPopID();
+
+            igSameLine(0, 4);
+
+            igPushID("BRUSH_INNER_RATIO");
+            igSetNextItemWidth(64);
+            incDragFloat(
+                "brush_inner_radtio", &innerRatio, 1,
+                0, 1, "%.2f", ImGuiSliderFlags.NoRoundToFormat);
+            igPopID();
+        igEndGroup();
+        return false;
+    }
+}

--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -10,6 +10,7 @@ module creator.viewport.common.mesheditor.operations.base;
 
 import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.mesheditor.tools.base;
+import creator.viewport.common.mesheditor.brushes;
 import i18n;
 import creator.viewport;
 import creator.viewport.common;
@@ -33,7 +34,7 @@ class IncMeshEditorOne {
 public:
     abstract void substituteMeshVertices(MeshVertex* meshVertex);
     abstract ulong getVertexFromPoint(vec2 mousePos);
-    abstract float[] getVerticesInBrush(vec2 mousePos, float radius);
+    abstract float[] getVerticesInBrush(vec2 mousePos, Brush brush);
     abstract void removeVertexAt(vec2 vertex);
     abstract bool removeVertex(ImGuiIO* io, bool selectedOnly);
     abstract bool addVertex(ImGuiIO* io);

--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -252,8 +252,6 @@ public:
     abstract CatmullSpline getPath();
     abstract void setPath(CatmullSpline path);
 
-    abstract void viewportTools(VertexToolMode mode);
-
     abstract void adjustPathTransform();
     abstract Tool getTool();
 }

--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -33,6 +33,7 @@ enum VertexToolMode {
     Connect,
     PathDeform,
     Grid,
+    Brush,
 }
 
 
@@ -40,6 +41,7 @@ class IncMeshEditorOne {
 public:
     abstract void substituteMeshVertices(MeshVertex* meshVertex);
     abstract ulong getVertexFromPoint(vec2 mousePos);
+    abstract float[] getVerticesInBrush(vec2 mousePos, float radius);
     abstract void removeVertexAt(vec2 vertex);
     abstract bool removeVertex(ImGuiIO* io, bool selectedOnly);
     abstract bool addVertex(ImGuiIO* io);

--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -8,6 +8,7 @@
 */
 module creator.viewport.common.mesheditor.operations.base;
 
+import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.mesheditor.tools.base;
 import i18n;
 import creator.viewport;
@@ -27,15 +28,6 @@ import bindbc.imgui;
 import std.algorithm.mutation;
 import std.algorithm.searching;
 import std.stdio;
-
-enum VertexToolMode {
-    Points,
-    Connect,
-    PathDeform,
-    Grid,
-    Brush,
-}
-
 
 class IncMeshEditorOne {
 public:

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -207,6 +207,11 @@ public:
     }
 
     override
+    float[] getVerticesInBrush(vec2 mousePos, float radius) {
+        return mesh.getVerticesInBrush(mousePos, radius);
+    }
+
+    override
     void removeVertexAt(vec2 vertex) {
         mesh.removeVertexAt(vertex);
     }
@@ -574,6 +579,16 @@ public:
             }
         }
         return -1;
+    }
+
+    override
+    float[] getVerticesInBrush(vec2 mousePos, float radius) {
+        float[] indices;
+        foreach(idx, ref vert; vertices) {
+            float distance = 1 - abs(vert.distance(mousePos)) / radius;
+            indices ~= max(distance, 0);
+        }
+        return indices;
     }
 
     override

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -12,6 +12,7 @@ import i18n;
 import creator.viewport;
 import creator.viewport.common;
 import creator.viewport.common.mesh;
+import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.mesheditor.operations;
 import creator.viewport.common.spline;
 import creator.core.input;

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -14,6 +14,7 @@ import creator.viewport.common;
 import creator.viewport.common.mesh;
 import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.mesheditor.operations;
+import creator.viewport.common.mesheditor.brushes;
 import creator.viewport.common.spline;
 import creator.core.input;
 import creator.core.actionstack;
@@ -208,8 +209,8 @@ public:
     }
 
     override
-    float[] getVerticesInBrush(vec2 mousePos, float radius) {
-        return mesh.getVerticesInBrush(mousePos, radius);
+    float[] getVerticesInBrush(vec2 mousePos, Brush brush) {
+        return mesh.getVerticesInBrush(mousePos, brush);
     }
 
     override
@@ -577,13 +578,8 @@ public:
     }
 
     override
-    float[] getVerticesInBrush(vec2 mousePos, float radius) {
-        float[] indices;
-        foreach(idx, ref vert; vertices) {
-            float distance = 1 - abs(vert.distance(mousePos)) / radius;
-            indices ~= max(distance, 0);
-        }
-        return indices;
+    float[] getVerticesInBrush(vec2 mousePos, Brush brush) {
+        return brush.weightsAt(mousePos, vertices);
     }
 
     override

--- a/source/creator/viewport/common/mesheditor/operations/drawable.d
+++ b/source/creator/viewport/common/mesheditor/operations/drawable.d
@@ -338,13 +338,7 @@ public:
             pushDeformAction();
         if (editorAction is null || !editorAction.action.isApplyable()) {
             auto deformAction = new DeformationAction(target.name, target);
-            switch (toolMode) {
-            case VertexToolMode.PathDeform:
-                editorAction = new MeshEditorPathDeformAction!DeformationAction(target, deformAction);
-                break;
-            default:
-                editorAction = new MeshEditorAction!DeformationAction(target, deformAction);
-            }
+            editorAction = tools[toolMode].editorAction(target, deformAction);
 
         } else {
             if (reset)
@@ -691,13 +685,7 @@ public:
             pushDeformAction();
         if (editorAction is null || !editorAction.action.isApplyable()) {
             auto deformAction = new DeformationAction(target.name, target);
-            switch (toolMode) {
-            case VertexToolMode.PathDeform:
-                editorAction = new MeshEditorPathDeformAction!DeformationAction(target, deformAction);
-                break;
-            default:
-                editorAction = new MeshEditorAction!DeformationAction(target, deformAction);
-            }
+            editorAction = tools[toolMode].editorAction(target, deformAction);
 
         } else {
             if (reset)

--- a/source/creator/viewport/common/mesheditor/operations/impl.d
+++ b/source/creator/viewport/common/mesheditor/operations/impl.d
@@ -92,29 +92,6 @@ public:
     }
 
     override
-    void viewportTools(VertexToolMode mode) {
-        switch (mode) {
-        case VertexToolMode.PathDeform:
-            setToolMode(mode);
-            setPath(new CatmullSpline);
-            deforming = false;
-            refreshMesh();
-            break;
-        case VertexToolMode.Grid:
-            setToolMode(mode);
-            setPath(null);
-            deforming = false;
-            refreshMesh();
-            break;
-        default:       
-            setToolMode(mode);
-            setPath(null);
-            refreshMesh();
-            break;
-        }
-    }
-
-    override
     void setToolMode(VertexToolMode toolMode) {
         if (toolMode in tools) {
             this.toolMode = toolMode;

--- a/source/creator/viewport/common/mesheditor/operations/impl.d
+++ b/source/creator/viewport/common/mesheditor/operations/impl.d
@@ -34,6 +34,7 @@ public:
         tools[VertexToolMode.Connect] = new ConnectTool;
         tools[VertexToolMode.PathDeform] = new PathDeformTool;
         tools[VertexToolMode.Grid] = new GridTool;
+        tools[VertexToolMode.Brush] = new BrushTool;
     }
 
     override

--- a/source/creator/viewport/common/mesheditor/operations/impl.d
+++ b/source/creator/viewport/common/mesheditor/operations/impl.d
@@ -21,6 +21,7 @@ import std.algorithm.mutation;
 import std.algorithm.searching;
 import std.stdio;
 
+
 class IncMeshEditorOneImpl(T) : IncMeshEditorOne {
 protected:
     T target;
@@ -30,11 +31,10 @@ protected:
 public:
     this(bool deformOnly) {
         super(deformOnly);
-        tools[VertexToolMode.Points] = new PointTool;
-        tools[VertexToolMode.Connect] = new ConnectTool;
-        tools[VertexToolMode.PathDeform] = new PathDeformTool;
-        tools[VertexToolMode.Grid] = new GridTool;
-        tools[VertexToolMode.Brush] = new BrushTool;
+        ToolInfo[] infoList = incGetToolInfo();
+        foreach (info; infoList) {
+            tools[info.mode()] = info.newTool();
+        }
     }
 
     override
@@ -94,31 +94,23 @@ public:
     override
     void viewportTools(VertexToolMode mode) {
         switch (mode) {
-        case VertexToolMode.Points:
-            setToolMode(VertexToolMode.Points);
-            setPath(null);
-            refreshMesh();
-            break;
-        case VertexToolMode.Connect:
-            setToolMode(VertexToolMode.Connect);
-            setPath(null);
-            refreshMesh();
-            break;
         case VertexToolMode.PathDeform:
-            import std.stdio;
-            setToolMode(VertexToolMode.PathDeform);
+            setToolMode(mode);
             setPath(new CatmullSpline);
             deforming = false;
             refreshMesh();
             break;
         case VertexToolMode.Grid:
-            import std.stdio;
-            setToolMode(VertexToolMode.Grid);
+            setToolMode(mode);
             setPath(null);
             deforming = false;
             refreshMesh();
             break;
         default:       
+            setToolMode(mode);
+            setPath(null);
+            refreshMesh();
+            break;
         }
     }
 

--- a/source/creator/viewport/common/mesheditor/operations/node.d
+++ b/source/creator/viewport/common/mesheditor/operations/node.d
@@ -13,6 +13,7 @@ import creator.viewport;
 import creator.viewport.common;
 import creator.viewport.common.mesh;
 import creator.viewport.common.mesheditor.operations;
+import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.spline;
 import creator.core.input;
 import creator.core.actionstack;

--- a/source/creator/viewport/common/mesheditor/operations/node.d
+++ b/source/creator/viewport/common/mesheditor/operations/node.d
@@ -14,6 +14,7 @@ import creator.viewport.common;
 import creator.viewport.common.mesh;
 import creator.viewport.common.mesheditor.operations;
 import creator.viewport.common.mesheditor.tools.enums;
+import creator.viewport.common.mesheditor.brushes;
 import creator.viewport.common.spline;
 import creator.core.input;
 import creator.core.actionstack;
@@ -210,9 +211,8 @@ public:
     }
     
     override
-    float[] getVerticesInBrush(vec2 mousePos, float radius) {
-        float distance = max(0, 1 - abs(translation.distance(mousePos)) / selectRadius);
-        return [distance];
+    float[] getVerticesInBrush(vec2 mousePos, Brush brush) {
+        return [brush.weightAt(mousePos, translation)];
     }
 
 

--- a/source/creator/viewport/common/mesheditor/operations/node.d
+++ b/source/creator/viewport/common/mesheditor/operations/node.d
@@ -213,6 +213,13 @@ public:
         if (abs(translation.distance(mousePos)) < selectRadius/incViewportZoom) return 0;
         return -1;
     }
+    
+    override
+    float[] getVerticesInBrush(vec2 mousePos, float radius) {
+        float distance = max(0, 1 - abs(translation.distance(mousePos)) / selectRadius);
+        return [distance];
+    }
+
 
     override void removeVertexAt(vec2 vertex) {}
     override bool removeVertex(ImGuiIO* io, bool selectedOnly) { return false; }

--- a/source/creator/viewport/common/mesheditor/operations/node.d
+++ b/source/creator/viewport/common/mesheditor/operations/node.d
@@ -151,13 +151,7 @@ public:
             registerBinding("transform.t.x", groupAction);
             registerBinding("transform.t.y", groupAction);
             registerBinding("transform.r.z", groupAction);
-            switch (toolMode) {
-            case VertexToolMode.PathDeform:
-                editorAction = new MeshEditorPathDeformAction!GroupAction(target, groupAction);
-                break;
-            default:
-                editorAction = new MeshEditorAction!GroupAction(target, groupAction);
-            }
+            editorAction = tools[toolMode].editorAction(target, groupAction);
         } else {
             if (reset) {
                 editorAction.clear();

--- a/source/creator/viewport/common/mesheditor/package.d
+++ b/source/creator/viewport/common/mesheditor/package.d
@@ -208,6 +208,13 @@ public:
                             e.viewportTools(VertexToolMode.PathDeform);
                     }
                     incTooltip(_("Path Deform Tool"));
+
+                    if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.Brush ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
+                        setToolMode(VertexToolMode.Brush);
+                        foreach (e; editors)
+                            e.viewportTools(VertexToolMode.Brush);
+                    }
+                    incTooltip(_("Brush Tool"));
                 }
 
                 if (!deformOnly) {

--- a/source/creator/viewport/common/mesheditor/package.d
+++ b/source/creator/viewport/common/mesheditor/package.d
@@ -32,7 +32,6 @@ import std.algorithm.mutation;
 import std.algorithm.searching;
 import std.stdio;
 
-
 class IncMeshEditor {
 private:
     IncMeshEditorOne[Node] editors;
@@ -185,45 +184,11 @@ public:
         igSetWindowFontScale(1.30);
             igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(1, 1));
             igPushStyleVar(ImGuiStyleVar.FramePadding, ImVec2(8, 10));
-                if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.Points ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
-                    setToolMode(VertexToolMode.Points);
-                    foreach (e; editors)
-                        e.viewportTools(VertexToolMode.Points);
-                }
-                incTooltip(_("Vertex Tool"));
-
-                if (!deformOnly) {
-                    if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.Connect ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
-                        setToolMode(VertexToolMode.Connect);
-                        foreach (e; editors)
-                            e.viewportTools(VertexToolMode.Connect);
+                auto info = incGetToolInfo();
+                foreach (i; info) {
+                    if (i.viewportTools(deformOnly, getToolMode(), editors)) {
+                        toolMode = i.mode();
                     }
-                    incTooltip(_("Edge Tool"));
-                }
-
-                if (deformOnly) {
-                    if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.PathDeform ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
-                        setToolMode(VertexToolMode.PathDeform);
-                        foreach (e; editors)
-                            e.viewportTools(VertexToolMode.PathDeform);
-                    }
-                    incTooltip(_("Path Deform Tool"));
-
-                    if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.Brush ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
-                        setToolMode(VertexToolMode.Brush);
-                        foreach (e; editors)
-                            e.viewportTools(VertexToolMode.Brush);
-                    }
-                    incTooltip(_("Brush Tool"));
-                }
-
-                if (!deformOnly) {
-                    if (incButtonColored("", ImVec2(0, 0), getToolMode() == VertexToolMode.Grid ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
-                        setToolMode(VertexToolMode.Grid);
-                        foreach (e; editors)
-                            e.viewportTools(VertexToolMode.Grid);
-                    }
-                    incTooltip(_("Grid Vertex Tool"));
                 }
 
             igPopStyleVar(2);
@@ -231,60 +196,10 @@ public:
     }
 
     void displayToolOptions() {
-        if (this.toolMode == VertexToolMode.PathDeform) {
-            igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0));
-            igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
-            auto deformTool = cast(PathDeformTool)(editors.length == 0 ? null: editors.values()[0].getTool());
-            igBeginGroup();
-                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Define)? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
-                    foreach (e; editors) {
-                        auto deform = cast(PathDeformTool)(e.getTool());
-                        if (deform !is null)
-                            deform.setMode(PathDeformTool.Mode.Define);
-                    }
-                }
-                incTooltip(_("Define paths"));
-
-                igSameLine(0, 0);
-
-                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Transform) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path deformation
-                    foreach (e; editors) {
-                        auto deform = cast(PathDeformTool)(e.getTool());
-                        if (deform !is null)
-                            deform.setMode(PathDeformTool.Mode.Transform);
-                    }
-                }
-                incTooltip(_("Transform path"));
-            igEndGroup();
-
-            igSameLine(0, 4);
-
-            igBeginGroup();
-                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.getIsRotateMode()) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // rotation mode
-                    foreach (e; editors) {
-                        auto deform = cast(PathDeformTool)(e.getTool());
-                        if (deform !is null)
-                            deform.setIsRotateMode(!deform.getIsRotateMode());
-                    }
-                }
-                incTooltip(_("Set rotation center"));
-            igEndGroup();
-
-            igSameLine(0, 4);
-
-            igBeginGroup();
-                if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.getIsShiftMode()) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // move shift
-                    foreach (e; editors) {
-                        auto deform = cast(PathDeformTool)(e.getTool());
-                        if (deform !is null)
-                            deform.setIsShiftMode(!deform.getIsShiftMode());
-                    }
-                }
-                incTooltip(_("Move points along the path"));
-            igEndGroup();
-
-
-            igPopStyleVar(2);
+        foreach (i; incGetToolInfo()) {
+            if (toolMode == i.mode) {
+                i.displayToolOptions(deformOnly, toolMode, editors);
+            }
         }
     }
 

--- a/source/creator/viewport/common/mesheditor/tools/base.d
+++ b/source/creator/viewport/common/mesheditor/tools/base.d
@@ -4,8 +4,8 @@ import i18n;
 import creator.viewport;
 import creator.viewport.common;
 import creator.viewport.common.mesh;
+import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.mesheditor.operations;
-import creator.viewport.common.spline;
 import creator.core.input;
 import creator.core.actionstack;
 import creator.actions;
@@ -19,7 +19,7 @@ import bindbc.imgui;
 import std.algorithm.mutation;
 import std.algorithm.searching;
 import std.stdio;
-
+import std.string: toStringz;
 
 interface Tool {
     int peek(ImGuiIO* io, IncMeshEditorOne impl);
@@ -34,4 +34,39 @@ interface Draggable {
     bool onDragStart(vec2 mousePos, IncMeshEditorOne impl);
     bool onDragUpdate(vec2 mousePos, IncMeshEditorOne impl);
     bool onDragEnd(vec2 mousePos, IncMeshEditorOne impl);
+}
+
+
+interface ToolInfo {
+    bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors);
+    bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors);
+    string icon();
+    string description();
+    VertexToolMode mode();
+    Tool newTool();
+}
+
+class ToolInfoBase(T) : ToolInfo {
+    override
+    bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
+        bool result = false;
+        if (incButtonColored(icon.toStringz, ImVec2(0, 0), toolMode == mode ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
+            result = true;
+            foreach (e; editors) {
+                e.setToolMode(toolMode);
+                e.viewportTools(mode);
+            }
+        }
+        incTooltip(description);
+        return result;
+    }
+    override
+    bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) { 
+        return false;
+    }
+    abstract VertexToolMode mode();
+    abstract string icon();
+    abstract string description();
+    override
+    Tool newTool() { return new T; }
 }

--- a/source/creator/viewport/common/mesheditor/tools/base.d
+++ b/source/creator/viewport/common/mesheditor/tools/base.d
@@ -21,12 +21,28 @@ import std.algorithm.searching;
 import std.stdio;
 import std.string: toStringz;
 
-interface Tool {
-    int peek(ImGuiIO* io, IncMeshEditorOne impl);
-    int unify(int[] actions);
-    bool update(ImGuiIO* io, IncMeshEditorOne impl, int action, out bool changed);
-    void setToolMode(VertexToolMode toolMode, IncMeshEditorOne impl);
-    void draw(Camera camera, IncMeshEditorOne impl);
+class Tool {
+    abstract int peek(ImGuiIO* io, IncMeshEditorOne impl);
+    abstract int unify(int[] actions);
+    abstract bool update(ImGuiIO* io, IncMeshEditorOne impl, int action, out bool changed);
+    abstract void setToolMode(VertexToolMode toolMode, IncMeshEditorOne impl);
+    abstract void draw(Camera camera, IncMeshEditorOne impl);
+
+    MeshEditorAction!DeformationAction editorAction(Node target, DeformationAction action) {
+        return new MeshEditorAction!(DeformationAction)(target, action);
+    }
+
+    MeshEditorAction!GroupAction editorAction(Node target, GroupAction action) {
+        return new MeshEditorAction!(GroupAction)(target, action);
+    }
+
+    MeshEditorAction!DeformationAction editorAction(Drawable target, DeformationAction action) {
+        return new MeshEditorAction!(DeformationAction)(target, action);
+    }
+
+    MeshEditorAction!GroupAction editorAction(Drawable target, GroupAction action) {
+        return new MeshEditorAction!(GroupAction)(target, action);
+    }
 }
 
 
@@ -36,25 +52,50 @@ interface Draggable {
     bool onDragEnd(vec2 mousePos, IncMeshEditorOne impl);
 }
 
-
+/// ToolInfo holds meta information and UI handling code for tools.
+/// Objects of this class are instantiated only once in the program, and stored into infoList array.
 interface ToolInfo {
+    /// viewportTools is called from MeshEditor, and displays tool icons
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors);
+
+    /// viewportTools is called from MeshEditor, and displays options for tool
     bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors);
+
+    /// icon returns material font strings for tool.
     string icon();
+
+    /// description returns tooltip text for tool.
     string description();
+
+    /// mode return VertexToolMode for tool. Should be removed in the future.
     VertexToolMode mode();
+
+    /// newTool returns new instance of tool.
     Tool newTool();
 }
 
+
+/// Base implementation of ToolInfo interface.
+/// Every instance of ToolInfo must inherit this class, and should be declared as ToolInfoImpl(class) template.
 class ToolInfoBase(T) : ToolInfo {
+
+    /// setupToolMode is called when tool are selected and being active.
+    /// This function setup all required setup for IncMeshEditorOne level.
+    /// Originally implemented directly in IncMeshEditorOneImpl, but move here
+    /// in order to decouple tools and oprations.
+    void setupToolMode(IncMeshEditorOne e, VertexToolMode mode) {
+        e.setToolMode(mode);
+        e.setPath(null);
+        e.refreshMesh();
+    }
+
     override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
         bool result = false;
         if (incButtonColored(icon.toStringz, ImVec2(0, 0), toolMode == mode ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
             result = true;
             foreach (e; editors) {
-                e.setToolMode(toolMode);
-                e.viewportTools(mode);
+                setupToolMode(e, mode);
             }
         }
         incTooltip(description);

--- a/source/creator/viewport/common/mesheditor/tools/brush.d
+++ b/source/creator/viewport/common/mesheditor/tools/brush.d
@@ -25,6 +25,7 @@ import std.algorithm.searching;
 import std.stdio;
 import std.math;
 import std.string;
+import std.range;
 
 private {
     Brush _currentBrush;
@@ -185,7 +186,9 @@ class BrushTool : NodeSelect {
             if (flow)
                 weights = impl.getVerticesInBrush(impl.mousePos, currentBrush);
             auto diffPos = impl.mousePos - impl.lastMousePos;
-            foreach (idx, weight; weights) {
+            ulong[] selected = (impl.selected && impl.selected.length > 0)? impl.selected: array(iota(weights.length));
+            foreach (idx; selected) {
+                float weight = weights[idx];
                 MeshVertex* v = impl.getVerticesByIndex([idx])[0];
                 if (v is null)
                     continue;
@@ -197,7 +200,8 @@ class BrushTool : NodeSelect {
 
             impl.refreshMesh();
             changed = true;
-        }
+        } else if (isDragging)
+            onDragUpdate(impl.mousePos, impl);
 
         if (changed) impl.refreshMesh();
         return changed;

--- a/source/creator/viewport/common/mesheditor/tools/brush.d
+++ b/source/creator/viewport/common/mesheditor/tools/brush.d
@@ -158,6 +158,10 @@ class BrushTool : NodeSelect {
 
     override 
     bool update(ImGuiIO* io, IncMeshEditorOne impl, int action, out bool changed) {
+        incStatusTooltip(_("Deform"), _("Left Mouse"));
+        incStatusTooltip(_("Snap to X/Y axis"), _("SHIFT"));
+        incStatusTooltip(_("Select vertices"), _("ALT"));
+
         // Left click selection
         if (action == SelectActionID.ToggleSelect) {
             if (impl.vtxAtMouse != ulong(-1))

--- a/source/creator/viewport/common/mesheditor/tools/brush.d
+++ b/source/creator/viewport/common/mesheditor/tools/brush.d
@@ -1,0 +1,196 @@
+module creator.viewport.common.mesheditor.tools.brush;
+import creator.viewport.common.mesheditor.tools.select;
+import creator.viewport.common.mesheditor.operations;
+import i18n;
+import creator.viewport;
+import creator.viewport.common;
+import creator.viewport.common.mesh;
+import creator.viewport.common.spline;
+import creator.core.input;
+import creator.core.actionstack;
+import creator.actions;
+import creator.ext;
+import creator.widgets;
+import creator;
+import inochi2d;
+import inochi2d.core.dbg;
+import bindbc.opengl;
+import bindbc.imgui;
+import std.algorithm.mutation;
+import std.algorithm.searching;
+import std.stdio;
+import std.math;
+
+class BrushTool : NodeSelect {
+    float radius = 300;
+    float getRadius() { return radius; }
+    void setRadius(float value) { radius = value; }
+
+    override bool onDragStart(vec2 mousePos, IncMeshEditorOne impl) {
+        return super.onDragStart(mousePos, impl);
+    }
+
+    override bool onDragEnd(vec2 mousePos, IncMeshEditorOne impl) {
+        return super.onDragEnd(mousePos, impl);
+    }
+
+    override bool onDragUpdate(vec2 mousePos, IncMeshEditorOne impl) {
+        if (isDragging && !impl.isSelecting) {
+            float[] weights = impl.getVerticesInBrush(impl.mousePos, radius);
+            auto diffPos = mousePos - impl.lastMousePos;
+            foreach (idx, weight; weights) {
+                MeshVertex* v = impl.getVerticesByIndex([idx])[0];
+                if (v is null)
+                    continue;
+                if (weight > 0) {
+                    v.position += diffPos * weight;
+                    impl.markActionDirty();
+                }
+            }
+
+            impl.refreshMesh();
+            return true;
+        }
+        return super.onDragUpdate(mousePos, impl);
+    }
+
+
+    enum BrushActionID {
+        Drawing = cast(int)(SelectActionID.End),
+        End
+    }
+
+    override
+    void setToolMode(VertexToolMode toolMode, IncMeshEditorOne impl) {
+        super.setToolMode(toolMode, impl);
+        incViewportSetAlwaysUpdate(true);
+    }
+
+    override 
+    int peek(ImGuiIO* io, IncMeshEditorOne impl) {
+        super.peek(io, impl);
+
+        if (incInputIsMouseReleased(ImGuiMouseButton.Left)) {
+            onDragEnd(impl.mousePos, impl);
+        }
+
+        if (igIsMouseClicked(ImGuiMouseButton.Left)) impl.maybeSelectOne = ulong(-1);
+        
+        int action = SelectActionID.None;
+
+        bool preDragging = isDragging;
+        if (incDragStartedInViewport(ImGuiMouseButton.Left) && igIsMouseDown(ImGuiMouseButton.Left) && incInputIsDragRequested(ImGuiMouseButton.Left)) {
+            isDragging = true;
+            onDragStart(impl.mousePos, impl);
+        }
+
+        if (isDragging) {
+            action = BrushActionID.Drawing;
+        }
+
+        if (action != SelectActionID.None)
+            return action;
+
+        if (io.KeyAlt) {
+            // Left click selection
+            if (igIsMouseClicked(ImGuiMouseButton.Left)) {
+                if (impl.isPointOver(impl.mousePos)) {
+                    if (io.KeyShift) return SelectActionID.ToggleSelect;
+                    else if (!impl.isSelected(impl.vtxAtMouse))  return SelectActionID.SelectOne;
+                    else return SelectActionID.MaybeSelectOne;
+                } else {
+                    return SelectActionID.SelectArea;
+                }
+            }
+            if (!isDragging && !impl.isSelecting &&
+                incInputIsMouseReleased(ImGuiMouseButton.Left) && impl.maybeSelectOne != ulong(-1)) {
+                return SelectActionID.SelectMaybeSelectOne;
+            }
+
+            // Dragging
+            if (incDragStartedInViewport(ImGuiMouseButton.Left) && igIsMouseDown(ImGuiMouseButton.Left) && incInputIsDragRequested(ImGuiMouseButton.Left)) {
+                if (!impl.isSelecting) {
+                    return SelectActionID.StartDrag;
+                }
+            }
+        }
+
+        return SelectActionID.None;
+
+    }
+
+    override
+    int unify(int[] actions) {
+        int[int] priorities;
+        priorities[BrushActionID.Drawing] = 0;
+        priorities[SelectActionID.None]                 = 10;
+        priorities[SelectActionID.SelectArea]           = 5;
+        priorities[SelectActionID.ToggleSelect]         = 2;
+        priorities[SelectActionID.SelectOne]            = 2;
+        priorities[SelectActionID.MaybeSelectOne]       = 2;
+        priorities[SelectActionID.StartDrag]            = 2;
+        priorities[SelectActionID.SelectMaybeSelectOne] = 2;
+
+        int action = SelectActionID.None;
+        int curPriority = priorities[action];
+        foreach (a; actions) {
+            auto newPriority = priorities[a];
+            if (newPriority < curPriority) {
+                curPriority = newPriority;
+                action = a;
+            }
+        }
+        return action;
+    }
+
+    override 
+    bool update(ImGuiIO* io, IncMeshEditorOne impl, int action, out bool changed) {
+        // Left click selection
+        if (action == SelectActionID.ToggleSelect) {
+            if (impl.vtxAtMouse != ulong(-1))
+                impl.toggleSelect(impl.vtxAtMouse);
+        } else if (action == SelectActionID.SelectOne) {
+            if (impl.vtxAtMouse != ulong(-1))
+                impl.selectOne(impl.vtxAtMouse);
+            else
+                impl.deselectAll();
+        } else if (action == SelectActionID.MaybeSelectOne) {
+            if (impl.vtxAtMouse != ulong(-1))
+                impl.maybeSelectOne = impl.vtxAtMouse;
+        } else if (action == SelectActionID.SelectArea) {
+            impl.selectOrigin = impl.mousePos;
+            impl.isSelecting = true;
+        }
+
+        if (action == SelectActionID.SelectMaybeSelectOne) {
+            if (impl.maybeSelectOne != ulong(-1))
+                impl.selectOne(impl.maybeSelectOne);
+        }
+
+        // Dragging
+        if (action == SelectActionID.StartDrag) {
+            onDragStart(impl.mousePos, impl);
+        }
+
+        if (isDragging) {
+            changed = onDragUpdate(impl.mousePos, impl) || changed;
+        }
+
+        if (changed) impl.refreshMesh();
+        return changed;
+    }
+
+    override
+    void draw(Camera camera, IncMeshEditorOne impl) {
+        super.draw(camera, impl);
+
+        vec3[] drawPoints;
+        drawPoints ~= vec3(impl.mousePos, 0);
+        inDbgSetBuffer(drawPoints);
+        inDbgPointsSize(radius * incViewportZoom * 2 + 4);
+        inDbgDrawPoints(vec4(0, 0, 0, 0.1), impl.transform);
+        inDbgPointsSize(2 * radius * incViewportZoom);
+        inDbgDrawPoints(vec4(1, 1, 1, 0.3), impl.transform);
+    }
+
+}

--- a/source/creator/viewport/common/mesheditor/tools/brush.d
+++ b/source/creator/viewport/common/mesheditor/tools/brush.d
@@ -81,7 +81,6 @@ class BrushTool : NodeSelect {
 
     override 
     int peek(ImGuiIO* io, IncMeshEditorOne impl) {
-        writeln("Brush::peek");
         super.peek(io, impl);
 
         if (incInputIsMouseReleased(ImGuiMouseButton.Left)) {
@@ -213,6 +212,54 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
         if (deformOnly)
             return super.viewportTools(deformOnly, toolMode, editors);
+        return false;
+    }
+    override
+    bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
+        igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0));
+        igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
+        auto brushTool = cast(BrushTool)(editors.length == 0 ? null: editors.values()[0].getTool());
+            igBeginGroup();
+                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                    foreach (e; editors) {
+                        auto bt = cast(BrushTool)(e.getTool());
+                        if (bt)
+                            bt.setFlow(false);
+                    }
+                }
+                incTooltip(_("Drag mode"));
+
+                igSameLine(0, 0);
+                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                    foreach (e; editors) {
+                        auto bt = cast(BrushTool)(e.getTool());
+                        if (bt)
+                            bt.setFlow(true);
+                    }
+                }
+                incTooltip(_("Flow mode"));
+
+            igEndGroup();
+
+            igSameLine(0, 4);
+
+            igBeginGroup();
+                igPushID("BRUSH_RADIUS");
+                igSetNextItemWidth(64);
+                if (incDragFloat(
+                    "brush_radius", &brushTool.radius, 1,
+                    1, 2000, "%.2f", ImGuiSliderFlags.NoRoundToFormat)
+                ) {
+                    foreach (e; editors) {
+                        auto bt = cast(BrushTool)(e.getTool());
+                        if (bt)
+                            bt.setRadius(brushTool.radius);
+                    }
+                }
+                igPopID();
+        
+            igEndGroup();
+        igPopStyleVar(2);
         return false;
     }
     override VertexToolMode mode() { return VertexToolMode.Brush; };

--- a/source/creator/viewport/common/mesheditor/tools/brush.d
+++ b/source/creator/viewport/common/mesheditor/tools/brush.d
@@ -24,14 +24,19 @@ import std.algorithm.mutation;
 import std.algorithm.searching;
 import std.stdio;
 import std.math;
+import std.string;
 
 private {
     Brush _currentBrush;
     Brush currentBrush() {
         if (_currentBrush is null) {
-            _currentBrush = new CircleBrush(300);
+            _currentBrush = incBrushList()[0];
         }
         return _currentBrush;
+    }
+    void setCurrentBrush(Brush brush) {
+        if (brush !is null)
+            _currentBrush = brush;
     }
 }
 
@@ -244,6 +249,22 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
 
             igSameLine(0, 4);
             currentBrush.configure();
+            igSameLine(0, 4);
+
+            igBeginGroup();
+            igPushID("BRUSH_SELECT");
+                auto brushName = currentBrush.name();
+                if(igBeginCombo("###Brushes", brushName.toStringz)) {
+                    foreach (brush; incBrushList) {
+                        if (igSelectable(brush.name().toStringz)) {
+                            setCurrentBrush(brush);
+                        }
+                    }
+                    igEndCombo();
+                }
+            igPopID();
+
+            igEndGroup();
         igPopStyleVar(2);
         return false;
     }

--- a/source/creator/viewport/common/mesheditor/tools/brush.d
+++ b/source/creator/viewport/common/mesheditor/tools/brush.d
@@ -226,7 +226,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
         igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
         auto brushTool = cast(BrushTool)(editors.length == 0 ? null: editors.values()[0].getTool());
             igBeginGroup();
-                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
                     foreach (e; editors) {
                         auto bt = cast(BrushTool)(e.getTool());
                         if (bt)
@@ -236,7 +236,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
                 incTooltip(_("Drag mode"));
 
                 igSameLine(0, 0);
-                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
                     foreach (e; editors) {
                         auto bt = cast(BrushTool)(e.getTool());
                         if (bt)

--- a/source/creator/viewport/common/mesheditor/tools/connect.d
+++ b/source/creator/viewport/common/mesheditor/tools/connect.d
@@ -1,5 +1,7 @@
 module creator.viewport.common.mesheditor.tools.connect;
 
+import creator.viewport.common.mesheditor.tools.enums;
+import creator.viewport.common.mesheditor.tools.base;
 import creator.viewport.common.mesheditor.tools.select;
 import creator.viewport.common.mesheditor.operations;
 import i18n;
@@ -99,4 +101,16 @@ class ConnectTool : NodeSelect {
             updateMeshEdit(io, impl, changed);
         return changed;
     }
+}
+
+class ToolInfoImpl(T: ConnectTool) : ToolInfoBase!(T) {
+    override
+    bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
+        if (!deformOnly)
+            return super.viewportTools(deformOnly, toolMode, editors);
+        return false;
+    }
+    override VertexToolMode mode() { return VertexToolMode.Connect; };
+    override string icon() { return "";}
+    override string description() { return _("Path Deform Tool");}
 }

--- a/source/creator/viewport/common/mesheditor/tools/enums.d
+++ b/source/creator/viewport/common/mesheditor/tools/enums.d
@@ -1,0 +1,9 @@
+module creator.viewport.common.mesheditor.tools.enums;
+
+enum VertexToolMode {
+    Points,
+    Connect,
+    PathDeform,
+    Grid,
+    Brush,
+};

--- a/source/creator/viewport/common/mesheditor/tools/grid.d
+++ b/source/creator/viewport/common/mesheditor/tools/grid.d
@@ -1,5 +1,7 @@
 module creator.viewport.common.mesheditor.tools.grid;
 
+import creator.viewport.common.mesheditor.tools.enums;
+import creator.viewport.common.mesheditor.tools.base;
 import creator.viewport.common.mesheditor.tools.select;
 import creator.viewport.common.mesheditor.operations;
 import i18n;
@@ -353,4 +355,16 @@ class GridTool : NodeSelect {
 
         }
     }
+}
+
+class ToolInfoImpl(T: GridTool) : ToolInfoBase!(T) {
+    override
+    bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
+        if (!deformOnly)
+            return super.viewportTools(deformOnly, toolMode, editors);
+        return false;
+    }
+    override VertexToolMode mode() { return VertexToolMode.Grid; };
+    override string icon() { return "";}
+    override string description() { return _("Grid Vertex Tool");}
 }

--- a/source/creator/viewport/common/mesheditor/tools/grid.d
+++ b/source/creator/viewport/common/mesheditor/tools/grid.d
@@ -359,6 +359,14 @@ class GridTool : NodeSelect {
 
 class ToolInfoImpl(T: GridTool) : ToolInfoBase!(T) {
     override
+    void setupToolMode(IncMeshEditorOne e, VertexToolMode mode) {
+        e.setToolMode(mode);
+        e.setPath(null);
+        e.deforming = false;
+        e.refreshMesh();
+    }
+
+    override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
         if (!deformOnly)
             return super.viewportTools(deformOnly, toolMode, editors);

--- a/source/creator/viewport/common/mesheditor/tools/package.d
+++ b/source/creator/viewport/common/mesheditor/tools/package.d
@@ -6,3 +6,4 @@ public import creator.viewport.common.mesheditor.tools.point;
 public import creator.viewport.common.mesheditor.tools.connect;
 public import creator.viewport.common.mesheditor.tools.pathdeform;
 public import creator.viewport.common.mesheditor.tools.grid;
+public import creator.viewport.common.mesheditor.tools.brush;

--- a/source/creator/viewport/common/mesheditor/tools/package.d
+++ b/source/creator/viewport/common/mesheditor/tools/package.d
@@ -1,5 +1,6 @@
 module creator.viewport.common.mesheditor.tools;
 
+public import creator.viewport.common.mesheditor.tools.enums;
 public import creator.viewport.common.mesheditor.tools.base;
 public import creator.viewport.common.mesheditor.tools.select;
 public import creator.viewport.common.mesheditor.tools.point;
@@ -7,3 +8,18 @@ public import creator.viewport.common.mesheditor.tools.connect;
 public import creator.viewport.common.mesheditor.tools.pathdeform;
 public import creator.viewport.common.mesheditor.tools.grid;
 public import creator.viewport.common.mesheditor.tools.brush;
+
+private {
+    ToolInfo[] infoList;
+}
+
+ToolInfo[] incGetToolInfo() {
+    if (infoList.length == 0) {
+        infoList ~= new ToolInfoImpl!(PointTool);
+        infoList ~= new ToolInfoImpl!(ConnectTool);
+        infoList ~= new ToolInfoImpl!(PathDeformTool);
+        infoList ~= new ToolInfoImpl!(GridTool);
+        infoList ~= new ToolInfoImpl!(BrushTool);
+    }
+    return infoList;
+}

--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -1,4 +1,7 @@
 module creator.viewport.common.mesheditor.tools.pathdeform;
+
+import creator.viewport.common.mesheditor.tools.enums;
+import creator.viewport.common.mesheditor.tools.base;
 import creator.viewport.common.mesheditor.tools.select;
 import creator.viewport.common.mesheditor.operations;
 import i18n;
@@ -353,4 +356,71 @@ class PathDeformTool : NodeSelect {
         }
     }
 
+}
+
+class ToolInfoImpl(T: PathDeformTool) : ToolInfoBase!(T) {
+    override
+    bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
+        if (deformOnly)
+            return super.viewportTools(deformOnly, toolMode, editors);
+        return false;
+    }
+    
+    override
+    bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) { 
+        igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0));
+        igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));        auto deformTool = cast(PathDeformTool)(editors.length == 0 ? null: editors.values()[0].getTool());
+        igBeginGroup();
+            if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Define)? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                foreach (e; editors) {
+                    auto deform = cast(PathDeformTool)(e.getTool());
+                    if (deform !is null)
+                        deform.setMode(PathDeformTool.Mode.Define);
+                }
+            }
+            incTooltip(_("Define paths"));
+
+            igSameLine(0, 0);
+
+            if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Transform) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path deformation
+                foreach (e; editors) {
+                    auto deform = cast(PathDeformTool)(e.getTool());
+                    if (deform !is null)
+                        deform.setMode(PathDeformTool.Mode.Transform);
+                }
+            }
+            incTooltip(_("Transform path"));
+        igEndGroup();
+
+        igSameLine(0, 4);
+
+        igBeginGroup();
+            if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.getIsRotateMode()) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // rotation mode
+                foreach (e; editors) {
+                    auto deform = cast(PathDeformTool)(e.getTool());
+                    if (deform !is null)
+                        deform.setIsRotateMode(!deform.getIsRotateMode());
+                }
+            }
+            incTooltip(_("Set rotation center"));
+        igEndGroup();
+
+        igSameLine(0, 4);
+
+        igBeginGroup();
+            if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.getIsShiftMode()) ? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // move shift
+                foreach (e; editors) {
+                    auto deform = cast(PathDeformTool)(e.getTool());
+                    if (deform !is null)
+                        deform.setIsShiftMode(!deform.getIsShiftMode());
+                }
+            }
+            incTooltip(_("Move points along the path"));
+        igEndGroup();
+        igPopStyleVar(2);
+        return false;
+    }
+    override VertexToolMode mode() { return VertexToolMode.PathDeform; }
+    override string icon() { return "";}
+    override string description() { return _("Path Deform Tool");}
 }

--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -356,13 +356,41 @@ class PathDeformTool : NodeSelect {
         }
     }
 
+    override
+    MeshEditorAction!DeformationAction editorAction(Node target, DeformationAction action) {
+        return new MeshEditorPathDeformAction!(DeformationAction)(target, action);
+    }
+
+    override
+    MeshEditorAction!GroupAction editorAction(Node target, GroupAction action) {
+        return new MeshEditorPathDeformAction!(GroupAction)(target, action);
+    }
+
+    override
+    MeshEditorAction!DeformationAction editorAction(Drawable target, DeformationAction action) {
+        return new MeshEditorPathDeformAction!(DeformationAction)(target, action);
+    }
+
+    override
+    MeshEditorAction!GroupAction editorAction(Drawable target, GroupAction action) {
+        return new MeshEditorPathDeformAction!(GroupAction)(target, action);
+    }
 }
 
 class ToolInfoImpl(T: PathDeformTool) : ToolInfoBase!(T) {
     override
+    void setupToolMode(IncMeshEditorOne e, VertexToolMode mode) {
+        e.setToolMode(mode);
+        e.setPath(new CatmullSpline);
+        e.deforming = false;
+        e.refreshMesh();
+    }
+
+    override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
-        if (deformOnly)
+        if (deformOnly) {
             return super.viewportTools(deformOnly, toolMode, editors);
+        }
         return false;
     }
     

--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -369,7 +369,8 @@ class ToolInfoImpl(T: PathDeformTool) : ToolInfoBase!(T) {
     override
     bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) { 
         igPushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0));
-        igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));        auto deformTool = cast(PathDeformTool)(editors.length == 0 ? null: editors.values()[0].getTool());
+        igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
+        auto deformTool = cast(PathDeformTool)(editors.length == 0 ? null: editors.values()[0].getTool());
         igBeginGroup();
             if (incButtonColored("", ImVec2(0, 0), (deformTool !is null && deformTool.mode == PathDeformTool.Mode.Define)? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
                 foreach (e; editors) {

--- a/source/creator/viewport/common/mesheditor/tools/point.d
+++ b/source/creator/viewport/common/mesheditor/tools/point.d
@@ -379,8 +379,6 @@ class PointTool : NodeSelect {
     }
 
     override int peek(ImGuiIO* io, IncMeshEditorOne impl) {
-        writeln("Point::peek");
-
         super.peek(io, impl);
         if (impl.deformOnly)
             return peekDeformEdit(io, impl);

--- a/source/creator/viewport/common/mesheditor/tools/point.d
+++ b/source/creator/viewport/common/mesheditor/tools/point.d
@@ -1,5 +1,7 @@
 module creator.viewport.common.mesheditor.tools.point;
 
+import creator.viewport.common.mesheditor.tools.enums;
+import creator.viewport.common.mesheditor.tools.base;
 import creator.viewport.common.mesheditor.tools.select;
 import creator.viewport.common.mesheditor.operations;
 import i18n;
@@ -377,6 +379,8 @@ class PointTool : NodeSelect {
     }
 
     override int peek(ImGuiIO* io, IncMeshEditorOne impl) {
+        writeln("Point::peek");
+
         super.peek(io, impl);
         if (impl.deformOnly)
             return peekDeformEdit(io, impl);
@@ -422,4 +426,13 @@ class PointTool : NodeSelect {
         return changed;
     }
 
+}
+
+class ToolInfoImpl(T: PointTool) : ToolInfoBase!(T) {
+    override
+    VertexToolMode mode() { return VertexToolMode.Points; }
+    override
+    string icon() { return ""; }
+    override
+    string description() { return _("Vertex Tool"); }
 }

--- a/source/creator/viewport/common/mesheditor/tools/select.d
+++ b/source/creator/viewport/common/mesheditor/tools/select.d
@@ -40,7 +40,7 @@ class NodeSelect : Tool, Draggable {
         assert(!impl.deformOnly || toolMode != VertexToolMode.Connect);
         isDragging = false;
         impl.isSelecting = false;
-//        impl.deselectAll();
+        incViewportSetAlwaysUpdate(false);
     }
 
     override 

--- a/source/creator/viewport/common/mesheditor/tools/select.d
+++ b/source/creator/viewport/common/mesheditor/tools/select.d
@@ -1,5 +1,6 @@
 module creator.viewport.common.mesheditor.tools.select;
 
+import creator.viewport.common.mesheditor.tools.enums;
 import creator.viewport.common.mesheditor.tools.base;
 import creator.viewport.common.mesheditor.operations;
 import i18n;

--- a/source/creator/viewport/package.d
+++ b/source/creator/viewport/package.d
@@ -282,7 +282,7 @@ void incEndDrag(int btn) {
 }
 
 bool incDragStartedInViewport(int btn) {
-    return isDraggingInViewport[btn];
+    return isDraggingInViewport[btn] && numDraggedOnHandle[btn] == 0;
 }
 
 bool incDragStartedOnHandle(int btn, string name) {
@@ -296,6 +296,7 @@ void incBeginDragInViewport(int btn) {
 void incBeginDragOnHandle(int btn, string name, vec2 prevValue = vec2(0,0)) {
     auto mpos = incInputGetMousePosition();
     isDraggingOnHandle[btn][name] = new DraggingOnHandle(mpos, prevValue);
+    numDraggedOnHandle[btn] ++;
 }
 
 bool incGetDragOriginOnHandle(int btn, string name, out vec2 mpos) {
@@ -336,6 +337,7 @@ void incEndDragInViewport(int btn) {
 
 void incEndDragOnHandle(int btn, string name) {
     isDraggingOnHandle[btn].remove(name);
+    numDraggedOnHandle[btn] --;
 }
 
 DraggingOnHandle incGetDragOnHandleStatus(int btn, string name) {
@@ -814,6 +816,7 @@ private {
     bool[ImGuiMouseButton.COUNT] isDraggingInViewport;
     DraggingOnHandle[string][ImGuiMouseButton.COUNT] isDraggingOnHandle;
     bool[ImGuiMouseButton.COUNT] isDragging;
+    int[ImGuiMouseButton.COUNT] numDraggedOnHandle = [0];
     bool isMovingViewport;
     float sx, sy;
     float csx, csy;

--- a/source/creator/viewport/package.d
+++ b/source/creator/viewport/package.d
@@ -254,8 +254,12 @@ bool incViewportAlwaysUpdate() {
     switch(incEditMode) {
         case EditMode.ModelTest:
             return true;
-        default: return false;
+        default: return alwaysUpdateMode;
     }
+}
+
+void incViewportSetAlwaysUpdate(bool value) {
+    alwaysUpdateMode = value;
 }
 
 /// For when there's no tools for that view
@@ -755,6 +759,8 @@ void incViewportReset() {
 //          Internal Viewport Stuff(TM)
 //
 private {
+    bool alwaysUpdateMode = false;
+
     enum LockedOrientation {
         None, Horizontal, Vertical
     };


### PR DESCRIPTION
Implemented new Brush tool for deformation. Users can drag area with brushmark selection, and drag vertices easily.

This patch also did a lot of refactoring so that tool can be implemented only by adding some modules into creator/viewport/common/mesheditor/tools directory. 

https://github.com/Inochi2D/inochi-creator/assets/449741/a3f0ae10-0ee7-4c84-bf62-cda535446f53

