### PR TITLE
[Feature] Add option to flip physics output axis

### DIFF
--- a/source/creator/panels/inspector.d
+++ b/source/creator/panels/inspector.d
@@ -1255,9 +1255,16 @@ void incInspectorModelSimplePhysics(SimplePhysics node) {
 
         igPushID("SimplePhysics");
         
-        igPushID(-1);
+        igPushID(-2);
             igCheckbox(__("Local Transform Lock"), &node.localOnly);
             incTooltip(_("Whether the physics system only listens to the movement of the physics node itself"));
+            igSpacing();
+            igSpacing();
+        igPopID();
+
+        igPushID(-1);
+            igCheckbox(__("Flip Output Axis"), &node.flipOutputAxis);
+            incTooltip(_("Flips the output axis so that the XY result gets mapped to YX values in the parameter"));
             igSpacing();
             igSpacing();
         igPopID();


### PR DESCRIPTION
This PR depends on https://github.com/Inochi2D/inochi2d/pull/57 to get merged and a session release afterwards for this feature to be useful.

This adds a checkbox to creator that let's you enable or disable the flip output axis option.

This was made with #337 in mind, but it can also be used for other purposes.

Here is an example of this feature in use.

[flip-output-axis.webm](https://github.com/Inochi2D/inochi-creator/assets/11585030/1cc011e4-ffdd-4dfb-9d6b-700292f9d41e)
