### PR TITLE
[Feature] Add extra map modes that work with flipped axis to Simple Physics

### DIFF
--- a/source/creator/panels/inspector.d
+++ b/source/creator/panels/inspector.d
@@ -1248,6 +1248,10 @@ void incInspectorModelSimplePhysics(SimplePhysics node) {
 
             if (igSelectable(__("XY"), node.mapMode == ParamMapMode.XY)) node.mapMode = ParamMapMode.XY;
 
+            if (igSelectable(__("LengthAngle"), node.mapMode == ParamMapMode.LengthAngle)) node.mapMode = ParamMapMode.LengthAngle;
+
+            if (igSelectable(__("YX"), node.mapMode == ParamMapMode.YX)) node.mapMode = ParamMapMode.YX;
+
             igEndCombo();
         }
 


### PR DESCRIPTION
Second iteration of #338 , this time depends on https://github.com/Inochi2D/inochi2d/pull/58

Same as before, this was made with #337 in mind

Here is an example of it being used in the #337 use case, and also using the spring part of the `Spring Pendulum` to animate the feeler bounciness in a 1D param.

https://github.com/Inochi2D/inochi-creator/assets/11585030/cee46a00-258a-40df-bc6d-cf6adb9edf9a

