### PR TITLE
Restore Edge Tool tooltip and icon

### DIFF
--- a/source/creator/viewport/common/mesheditor/tools/connect.d
+++ b/source/creator/viewport/common/mesheditor/tools/connect.d
@@ -111,6 +111,6 @@ class ToolInfoImpl(T: ConnectTool) : ToolInfoBase!(T) {
         return false;
     }
     override VertexToolMode mode() { return VertexToolMode.Connect; };
-    override string icon() { return "";}
-    override string description() { return _("Path Deform Tool");}
+    override string icon() { return "";}
+    override string description() { return _("Edge Tool");}
 }


### PR DESCRIPTION
During one of the brush tool refactors, the Edge tool name and icon got lost. This commit restores them :+1: 
 