### PR TITLE
Fix path deform tool crashing on meshless nodes

### DIFF
--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -290,13 +290,17 @@ class PathDeformTool : NodeSelect {
             }
 
         } else if (action == PathDeformActionID.Shift || action == PathDeformActionID.StartShiftTransform) {
-            float off = path.findClosestPointOffset(impl.mousePos);
-            vec2 pos  = path.eval(off);
-            editPath.points[pathDragTarget].position = pos;
+            if(pathDragTarget != -1){
+                float off = path.findClosestPointOffset(impl.mousePos);
+                vec2 pos  = path.eval(off);
+                editPath.points[pathDragTarget].position = pos;
+            }
         
         } else if (action == PathDeformActionID.Transform || action == PathDeformActionID.StartTransform) {
-            vec2 relTranslation = impl.mousePos - impl.lastMousePos;
-            editPath.points[pathDragTarget].position += relTranslation;
+            if(pathDragTarget != -1){
+                vec2 relTranslation = impl.mousePos - impl.lastMousePos;
+                editPath.points[pathDragTarget].position += relTranslation;
+            }
         }
 
         editPath.update();

--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -250,7 +250,8 @@ class PathDeformTool : NodeSelect {
         }
 
         if (action == PathDeformActionID.StartTransform || action == PathDeformActionID.StartShiftTransform) {
-            (cast(MeshEditorAction!DeformationAction)(impl.getDeformAction())).clear();
+            auto deform = (cast(MeshEditorAction!DeformationAction)(impl.getDeformAction()));
+            if(deform !is null) deform.clear();
         }
 
         if (action == PathDeformActionID.RemovePoint || action == PathDeformActionID.AddPoint) {

--- a/source/creator/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/creator/viewport/common/mesheditor/tools/pathdeform.d
@@ -257,7 +257,7 @@ class PathDeformTool : NodeSelect {
         if (action == PathDeformActionID.RemovePoint || action == PathDeformActionID.AddPoint) {
             if (action == PathDeformActionID.RemovePoint) {
                 int idx = path.findPoint(impl.mousePos);
-                path.removePoint(idx);
+                if(idx != -1) path.removePoint(idx);
             } else if (action == PathDeformActionID.AddPoint) {
                 path.addPoint(impl.mousePos);
             }

--- a/source/creator/viewport/common/spline.d
+++ b/source/creator/viewport/common/spline.d
@@ -175,6 +175,10 @@ public:
         return mat4.identity();
     }
 
+    mat4 exportTarget(T)(ref T mesh, size_t i, ref vec2 vtx, vec2 tangent, vec2 initTangent) {
+        return mat4.identity();
+    }
+
     mat4 exportTarget(ref IncMesh mesh, size_t i, ref vec2 vtx, vec2 tangent, vec2 initTangent, mat4 invert, vec2 deformation) {
         mesh.vertices[i].position = (invert * vec4(vtx, 0, 1)).xy - deformation;
         return mat4.identity();
@@ -252,7 +256,11 @@ public:
                 pt.y + rel.y * tangent.x + rel.x * tangent.y
             );
 //             writefln("%s %s %s", vtx, rel, tangent);
-            result = exportTarget(mesh, i, vtx, tangent, initTangents.length > i ? initTangents[i]: tangent, invert, deformations[i]);
+            if(deformations is null){
+                result = exportTarget(mesh, i, vtx, tangent, initTangents.length > i ? initTangents[i]: tangent);
+            } else {
+                result = exportTarget(mesh, i, vtx, tangent, initTangents.length > i ? initTangents[i]: tangent, invert, deformations[i]);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Attempt to fix #324

Debugged the app and noticed that it crashes when `updateTarget` is called with a `null` `deformations` parameter, which is the default value for that parameter and its used when calling it for a `Node` instead of a `Mesh`.

Tried to fix it by calling a version of the `exportTarget` function that expects a `Node` and has less parameters when `deformations` is `null`, but the compiler wont recognize that as an option if there is no generic declaration of `exportTarget` with less parameters (I imagine that this is either a limitation of using generics in D or a misunderstanding on my side on how things work on dlang).

I tested and the fix worked, but I found another crash in the process when I tried to move one of the points in the path while the path tool was in `Transform Path` mode. Noticed that this was because the implementation had parts that assumed that the tool would only be used with meshes. Cleaned that up and it seems to work fine :).