### PR TITLE
Fix crash when iterating into unpaired flip pairings

### DIFF
--- a/source/creator/panels/parameters.d
+++ b/source/creator/panels/parameters.d
@@ -934,7 +934,7 @@ void incParameterView(bool armedParam=false)(size_t idx, Parameter param, string
                             pasteParameter(param, 2);
                             incViewportNodeDeformNotifyParamValueChanged();
                         }
-                        if (igMenuItem(__("Paste and Horiontal Flip"), "", false, true)) {
+                        if (igMenuItem(__("Paste and Horizontal Flip"), "", false, true)) {
                             pasteParameter(param, 0);
                             incViewportNodeDeformNotifyParamValueChanged();
                         }

--- a/source/creator/windows/flipconfig.d
+++ b/source/creator/windows/flipconfig.d
@@ -132,7 +132,7 @@ FlipPair[] incGetFlipPairs() {
 
 FlipPair incGetFlipPairFor(Node node) {
     foreach (pair; flipPairs) {
-        if (pair.parts[0].uuid == node.uuid || pair.parts[1].uuid == node.uuid) {
+        if (pair.parts[1] !is null && (pair.parts[0].uuid == node.uuid || pair.parts[1].uuid == node.uuid)) {
             return pair;
         }
     }


### PR DESCRIPTION
Fixes #336 

Crash is caused when trying to search a flip pairings. It's triggered when there are pairings that don't have a set pair and you search for an element that is not in the list or further down the unpaired list.