### PR TITLE
Fix Krita document import tooltip

### DIFF
--- a/source/creator/widgets/mainmenu.d
+++ b/source/creator/widgets/mainmenu.d
@@ -177,7 +177,7 @@ void incMainMenu() {
                             incPopWelcomeWindow();
                             incImportShowKRADialog();
                         }
-                        incTooltip(_("Import a standard Photoshop PSD file."));
+                        incTooltip(_("Import a standard Krita KRA file."));
 
                         if (igMenuItem(__("Inochi2D Puppet"), "", false, true)) {
                             const TFD_Filter[] filters = [


### PR DESCRIPTION
The tooltip that appears when you hover over "Krita Document" in the Import menu is the same as the "Photoshop Document" one.