### PR TITLE
minor bug fixes in v0.8.5

### DIFF
--- a/source/creator/actions/node.d
+++ b/source/creator/actions/node.d
@@ -30,6 +30,7 @@ public:
         Which index in to the parent the nodes should be placed
     */
     size_t parentOffset;
+    float[uint] zSort;
 
     /**
         Previous parent of node
@@ -76,6 +77,7 @@ public:
                 originalTransform[sn.uuid] = sn.localTransform;
                 prevParents[sn.uuid] = sn.parent;
                 prevOffsets[sn.uuid] = sn.getIndexInParent();
+                zSort[sn.uuid] = sn.zSort;
             }
 
             // Set relative position
@@ -100,6 +102,9 @@ public:
             if (sn.uuid in prevParents && prevParents[sn.uuid]) {
                 if (!sn.lockToRoot()) sn.setRelativeTo(prevParents[sn.uuid]);
                 sn.reparent(prevParents[sn.uuid], prevOffsets[sn.uuid]);
+                if (sn.uuid in zSort) {
+                    sn.zSort = zSort[sn.uuid] - prevParents[sn.uuid].zSort();
+                }
                 sn.localTransform = originalTransform[sn.uuid];
                 sn.transformChanged();
             } else sn.parent = null;

--- a/source/creator/io/package.d
+++ b/source/creator/io/package.d
@@ -14,6 +14,7 @@ public import creator.io.imageexport;
 import tinyfiledialogs;
 public import tinyfiledialogs : TFD_Filter;
 import std.string;
+import std.uri;
 import i18n;
 
 import bindbc.sdl;
@@ -80,7 +81,7 @@ string incShowImportDialog(const(TFD_Filter)[] filters, string title, bool multi
             op.multiple = multiple;
             auto promise = dpFileChooserOpenFile(getWindowHandle(), title, op);
             promise.await();
-            return promise.uriFromPromise();
+            return promise.uriFromPromise().decode;
         } catch (Throwable ex) {
 
             // FALLBACK: If xdg-desktop-portal is not available then try tinyfiledialogs.
@@ -108,7 +109,7 @@ string incShowOpenFolderDialog(string title = "Open...") {
             op.directory = true;
             auto promise = dpFileChooserOpenFile(getWindowHandle(), title, op);
             promise.await();
-            return promise.uriFromPromise();
+            return promise.uriFromPromise().decode;
         } catch (Throwable _) {
 
             // FALLBACK: If xdg-desktop-portal is not available then try tinyfiledialogs.
@@ -132,7 +133,7 @@ string incShowOpenDialog(const(TFD_Filter)[] filters, string title = "Open...") 
             op.filters = tfdToFileFilter(filters);
             auto promise = dpFileChooserOpenFile(getWindowHandle(), title, op);
             promise.await();
-            return promise.uriFromPromise();
+            return promise.uriFromPromise().decode;
         } catch (Throwable ex) {
 
             // FALLBACK: If xdg-desktop-portal is not available then try tinyfiledialogs.
@@ -160,7 +161,7 @@ string incShowSaveDialog(const(TFD_Filter)[] filters, string fname, string title
             op.filters = tfdToFileFilter(filters);
             auto promise = dpFileChooserSaveFile(getWindowHandle(), title, op);
             promise.await();
-            return promise.uriFromPromise();
+            return promise.uriFromPromise().decode;
         } catch (Throwable ex) {
 
             // FALLBACK: If xdg-desktop-portal is not available then try tinyfiledialogs.

--- a/source/creator/panels/inspector.d
+++ b/source/creator/panels/inspector.d
@@ -21,6 +21,7 @@ import std.string;
 import std.algorithm.searching;
 import std.algorithm.mutation;
 import std.conv;
+import std.utf;
 import i18n;
 
 // Drag drop data
@@ -281,7 +282,11 @@ void incModelModeHeader(Node node) {
     igPushID(node.uuid);
         string typeString = "%s".format(incTypeIdToIcon(node.typeId()));
         auto len = incMeasureString(typeString);
-        incInputText("###MODEL_NODE_HEADER", incAvailableSpace().x-24, node.name);
+        if (incInputText("###MODEL_NODE_HEADER", incAvailableSpace().x-24, node.name)) {
+            try {
+                node.name = node.name.toStringz.fromStringz;
+            } catch (std.utf.UTFException e) {}
+        }
         igSameLine(0, 0);
         incDummy(ImVec2(-len.x, len.y));
         igSameLine(0, 0);

--- a/source/creator/windows/flipconfig.d
+++ b/source/creator/windows/flipconfig.d
@@ -132,7 +132,9 @@ FlipPair[] incGetFlipPairs() {
 
 FlipPair incGetFlipPairFor(Node node) {
     foreach (pair; flipPairs) {
-        if (pair.parts[1] !is null && (pair.parts[0].uuid == node.uuid || pair.parts[1].uuid == node.uuid)) {
+        if (pair.parts[0] !is null &&
+            pair.parts[1] !is null &&
+            (pair.parts[0].uuid == node.uuid || pair.parts[1].uuid == node.uuid)) {
             return pair;
         }
     }
@@ -159,24 +161,13 @@ private:
 
 
     void autoPair(string part1, string part2) {
-        // FIXME: this code sometimes doesn't work well with multi-byte utf-8 charset.
-        string truncate(string str) {
-            int i;
-            for (i = (cast(int)str.length) - 1; i >= 0; i --) {
-                if (str[i] != '\0')
-                    break;
-            }
-            if (i >= 0) {
-                return str[0..i];
-            }
-            return "";
-        }
-
         foreach(i, ref Node node; nodes) {
-            string targetName = node.name.replace(part1, part2);
+            string node1Name = node.name.toStringz.fromStringz;
+            string targetName = node1Name.replace(part1, part2);
             if (node.uuid in map) continue;
             foreach (ref Node node2; nodes) {
-                if (node.name.indexOf(part1) >= 0 && truncate(node2.name) == truncate(targetName)) {
+                string node2Name = node2.name.toStringz.fromStringz;
+                if (node1Name.indexOf(part1) >= 0 && node2Name == targetName) {
                     if (node2.uuid != node.uuid) {
                         pairs ~= new FlipPair([node, node2], "");
                         map[node.uuid] = pairs.length - 1;


### PR DESCRIPTION
Four bug fixes.
1) zSort order is not restored from delete operation.
2) File chooser doesn't work with directories which contains non-ASCII characters in Linux. (escaped by dportal)
3) Improve null-terminated string in inspector.
4) Fixed handling of null-terminated characters in FlipConfig pair search.