### PR TITLE
Fixed Comment Describing Children Deletion

### DIFF
--- a/source/creator/actions/node.d
+++ b/source/creator/actions/node.d
@@ -371,7 +371,7 @@ void incDeleteChildWithHistory(Node n) {
 }
 
 /**
-    Deletes child with history
+    Deletes multiple children with history
 */
 void incDeleteChildrenWithHistory(Node[] ns) {
     GroupAction group = null;


### PR DESCRIPTION
I've found a repeated comment while working on one of my issues. This change elaborates on the comment above `incDeleteChildrenWithHistory(Node[] ns)` that multiple children would be deleted, rather than a single child.