### PR TITLE
Settings: Handle corrupted settings file and provide error dialog 

### DIFF
--- a/source/creator/core/package.d
+++ b/source/creator/core/package.d
@@ -624,8 +624,12 @@ void incBeginLoopNoEv() {
     // HACK: ImGui Crashes if a popup is rendered on the first frame, let's avoid that.
     if (firstFrame) firstFrame = false;
     else {
-        incModalRender();
-        incRenderDialogs();
+        // imgui can not igOpenPopup two popups at the same time, that causes a freeze
+        // so we sperate the popups rendering
+        if (incModalIsOpen())
+            incModalRender();
+        else
+            incRenderDialogs();
     }
     incStatusUpdate();
 

--- a/source/creator/core/settings.d
+++ b/source/creator/core/settings.d
@@ -20,9 +20,9 @@ string incSettingsPath() {
 }
 
 string incSettingsMoveCorruptedFile(string path) {
-    import std.uuid : randomUUID;
+    import std.datetime;
     // move the corrupted settings file to a new location
-    string backupPath = path ~ "." ~ randomUUID().toString();
+    string backupPath = path ~ "." ~ Clock.currTime().toISOString();
     rename(path, backupPath);
     return backupPath;
 }

--- a/source/creator/core/settings.d
+++ b/source/creator/core/settings.d
@@ -9,6 +9,7 @@ import std.json;
 import std.file;
 import std.path : buildPath;
 import creator.core.path;
+import i18n;
 
 private {
     JSONValue settings = JSONValue(string[string].init);
@@ -18,18 +19,48 @@ string incSettingsPath() {
     return buildPath(incGetAppConfigPath(), "settings.json");
 }
 
+string incSettingsMoveCorruptedFile(string path) {
+    import std.uuid : randomUUID;
+    // move the corrupted settings file to a new location
+    string backupPath = path ~ "." ~ randomUUID().toString();
+    rename(path, backupPath);
+    return backupPath;
+}
+
+void incSettingsErrorDialog(Exception ex, string backupPath) {
+    import creator.widgets.dialog;
+    string error = _("Oops! Your settings.json file is corrupted. inochi2d creator will load the default settings.\n");
+    error ~= _("The corrupted settings file has been moved to ") ~ backupPath ~ ".\n";
+    error ~= _("If you always see this message, please report this issue to inochi2d creator\n");
+    error ~= _("\nError message: ") ~ ex.msg;
+    incDialog(__("Error"), error);
+}
+
 /**
     Load settings from settings file
 */
 void incSettingsLoad() {
     if (exists(incSettingsPath())) {
-        settings = parseJSON(readText(incSettingsPath()));
+        try {
+            settings = parseJSON(readText(incSettingsPath()));
 
-        // File Handling
-        // Always ask the user whether to preserve the folder structure during import
-        // also see incGetKeepLayerFolder()
-        settings["KeepLayerFolder"] = "Ask";
+            // check settings is not empty
+            if (settings.object.length == 0)
+                throw new JSONException("Settings file is empty");
+            return;
+        } catch (JSONException ex) {
+            string backupPath = incSettingsMoveCorruptedFile(incSettingsPath());
+            incSettingsErrorDialog(ex, backupPath);
+        }
     }
+
+    // This code is used to configure default values for new users
+    // New users use MousePosition, old users keep ScreenCenter
+
+    // File Handling
+    // Always ask the user whether to preserve the folder structure during import
+    // also see incGetKeepLayerFolder()
+    settings["KeepLayerFolder"] = "Ask";
 }
 
 /**

--- a/source/creator/widgets/modal/package.d
+++ b/source/creator/widgets/modal/package.d
@@ -97,6 +97,12 @@ void incModalRender() {
         incModalList[incModalIndex].update();
     }
 }
+/** 
+    incModalIsOpen returns true if a modal is open
+*/
+bool incModalIsOpen() {
+    return incModalIndex > -1;
+}
 
 /**
     Adds a modal to the modal display list.


### PR DESCRIPTION
Avoid inochi-creator unavailability when users settings.json is corrupted

## The following issues:
- Invalid UTF sequence
  - https://github.com/Inochi2D/inochi-creator/issues/183
- JSONValue is not an object
  - https://github.com/Inochi2D/inochi-creator/issues/331
- Unexpected end of data
  - https://github.com/Inochi2D/inochi-creator/issues/167
  - https://github.com/Inochi2D/inochi-creator/issues/387
  - https://github.com/Inochi2D/inochi-creator/issues/332

## Analyze
- **Invalid UTF sequence**: It may be these two issues that cause settings.json to become corrupt.
  - https://github.com/Inochi2D/inochi-creator/issues/378
  - https://github.com/Inochi2D/inochi-creator/issues/392 
- **JSONValue is not an object**: Empty settings.json
- **Unexpected end of data**: Incomplete settings.json, Remove last json character `}`