### PR TITLE
Experimental: Add SizeSort for Viewport Right Click Menu Sorting

### DIFF
--- a/source/creator/viewport/model/package.d
+++ b/source/creator/viewport/model/package.d
@@ -27,6 +27,19 @@ private {
     enum ENTRY_SIZE = 48;
 }
 
+enum ViewporMenuSortMode {
+    ZSort,
+    SizeSort,
+}
+
+/** 
+    Default to SizeSort because when selecting objects, especially detailed puppets 
+    or small components, we assume the user will point directly at the one they want. 
+    Prioritizing smaller objects makes them easier to select, while larger objects 
+    can usually be selected by clicking elsewhere if needed.
+*/
+ViewporMenuSortMode incViewportModelMenuSortMode = ViewporMenuSortMode.SizeSort;
+
 void incViewportModelMenuOpening() {
     foundParts.length = 0;
 
@@ -46,9 +59,20 @@ void incViewportModelMenuOpening() {
     import std.algorithm.sorting : sort;
     import std.algorithm.mutation : SwapStrategy;
     import std.math : cmp;
-    sort!((a, b) => cmp(
-        a.zSortNoOffset, 
-        b.zSortNoOffset) < 0, SwapStrategy.stable)(foundParts);
+
+    if (incViewportModelMenuSortMode == ViewporMenuSortMode.ZSort) {
+        sort!((a, b) => cmp(
+            a.zSortNoOffset, 
+            b.zSortNoOffset) < 0, SwapStrategy.stable)(foundParts);
+
+    } else if (incViewportModelMenuSortMode == ViewporMenuSortMode.SizeSort) {
+        sort!((a, b) => cmp(
+            (a.bounds.z - a.bounds.x) * (a.bounds.w - a.bounds.y), 
+            (b.bounds.z - b.bounds.x) * (b.bounds.w - b.bounds.y)) < 0, SwapStrategy.stable)(foundParts);
+
+    } else {
+        throw new Exception("Unknown sort mode");
+    }
 }
 
 void incViewportModelMenu() {

--- a/source/creator/viewport/model/package.d
+++ b/source/creator/viewport/model/package.d
@@ -27,18 +27,17 @@ private {
     enum ENTRY_SIZE = 48;
 }
 
+/** 
+    For detailed puppets or small components, we assume the user will directly point to the one they want. 
+    ZSort is slightly less effective than SizeSort on layers with more alpha pixels (e.g., hair overlapping eyes). 
+    SizeSort prioritizes smaller objects, making them easier to select.
+*/
 enum ViewporMenuSortMode {
     ZSort,
     SizeSort,
 }
 
-/** 
-    Default to SizeSort because when selecting objects, especially detailed puppets 
-    or small components, we assume the user will point directly at the one they want. 
-    Prioritizing smaller objects makes them easier to select, while larger objects 
-    can usually be selected by clicking elsewhere if needed.
-*/
-ViewporMenuSortMode incViewportModelMenuSortMode = ViewporMenuSortMode.SizeSort;
+ViewporMenuSortMode incViewportModelMenuSortMode = ViewporMenuSortMode.ZSort;
 
 void incViewportModelMenuOpening() {
     foundParts.length = 0;

--- a/source/creator/viewport/model/package.d
+++ b/source/creator/viewport/model/package.d
@@ -79,7 +79,14 @@ void incViewportModelMenu() {
     if (auto editor = incViewportModelDeformGetEditor()) {
         editor.popupMenu();
     }
-    igNewLine();
+
+    if (igMenuItem(incViewportModelMenuSortMode == ViewporMenuSortMode.ZSort ? __("Z-Sort") : __("Size-Sort"))) {
+        if (incViewportModelMenuSortMode == ViewporMenuSortMode.ZSort)
+            incViewportModelMenuSortMode = ViewporMenuSortMode.SizeSort;
+        else
+            incViewportModelMenuSortMode = ViewporMenuSortMode.ZSort;
+    }
+
     igSeparator();
     
     if (incSelectedNode() != incActivePuppet().root) {


### PR DESCRIPTION
## Summary
This PR introduces a new sorting method based on object size and sets in the viewport right-click menu.

## Details
- **Heuristic**: Prioritizing smaller objects makes it easier for users to select intricate items they are pointing at, while larger objects can still be selected by clicking elsewhere if needed.
- **Comparison**: 
  - Z sorting may produce unreliable results when objects contain a lot of alpha pixels.
  - Other solutions that use pixel or mesh-based intersection calculations can reduce performance and increase complexity. The `SizeSort` approach avoids these issues, offering a simpler alternative.
  - Combining `SizeSort` and `ZSort` to produce a composite sorting value is a potential enhancement. We can explore automatically adjusting to the optimal solution based on user feedback to further improve sorting accuracy and user experience.

## Benefits

- Enhanced usability when dealing with detailed or small components. 
- More intuitive selection process for users. 

## Demo
Zsort
<img width="296" alt="image" src="https://github.com/user-attachments/assets/b2b82ef5-0230-4226-b502-a6e7b478860d">
size sort
<img width="334" alt="image" src="https://github.com/user-attachments/assets/ad80f22b-b749-4df4-b9cc-75cc02f0824a">
Click the first item to toggle (zsort)
<img width="313" alt="image" src="https://github.com/user-attachments/assets/add04760-b345-4d5a-bd08-e92d63e31b57">
