### PR TITLE
Added autoConnect Feature

### DIFF
--- a/source/creator/viewport/common/mesheditor/operations/base.d
+++ b/source/creator/viewport/common/mesheditor/operations/base.d
@@ -64,12 +64,24 @@ public:
     bool mutateSelection = false;
     bool invertSelection = false;
     ulong maybeSelectOne;
+
+    // you should call updateVtxAtMouse() for updating vtxAtMouse
+    // because it also updates prevVtxAtMouse
     ulong vtxAtMouse;
+    ulong prevVtxAtMouse;
+
     vec2 selectOrigin;
     IncMesh previewMesh;
 
     bool deforming = false;
     float meshEditAOE = 4;
+
+    void updateVtxAtMouse(ulong vtxIndex) {
+        // we hope prevVtxAtMouse tracks the previous != -1 vtxAtMouse
+        if (vtxAtMouse != -1)
+            prevVtxAtMouse = vtxAtMouse;
+        vtxAtMouse = vtxIndex;
+    }
 
     bool isSelected(ulong vertIndex) {
         import std.algorithm.searching : canFind;
@@ -150,6 +162,14 @@ public:
         return vInd;
     }
 
+    MeshVertex* mirrorVertex(uint axis, MeshVertex* vtx) {
+        if (axis == 0) return vtx;
+        ulong vInd = getVertexFromPoint(mirror(axis, vtx.position));
+        MeshVertex* v = getVerticesByIndex([vInd])[0];
+        if (v is null || v == vtx) return null;
+        return getVerticesByIndex([vInd])[0];
+    }
+
     bool isOnMirror(vec2 pos, float aoe) {
         return 
             (mirrorVert && pos.y > -aoe && pos.y < aoe) ||
@@ -211,6 +231,7 @@ public:
 
     this(bool deformOnly) {
         this.deformOnly = deformOnly;
+        prevVtxAtMouse = ulong(-1);
     }
 
     VertexToolMode getToolMode() {

--- a/source/creator/viewport/common/mesheditor/tools/grid.d
+++ b/source/creator/viewport/common/mesheditor/tools/grid.d
@@ -272,7 +272,7 @@ class GridTool : NodeSelect {
                     meshData.regenerateGrid();
                     mesh.copyFromMeshData(meshData);
                     impl.refreshMesh();
-                    impl.vtxAtMouse = ulong(-1);
+                    impl.updateVtxAtMouse(ulong(-1));
                 }
 
             } else {

--- a/source/creator/viewport/common/mesheditor/tools/point.d
+++ b/source/creator/viewport/common/mesheditor/tools/point.d
@@ -25,6 +25,7 @@ import std.stdio;
 
 class PointTool : NodeSelect {
     Action action;
+    bool autoConnect = true;
 
     override bool onDragStart(vec2 mousePos, IncMeshEditorOne impl) {
         if (!impl.deformOnly) {
@@ -129,32 +130,60 @@ class PointTool : NodeSelect {
                     impl.selected.length = 0;
                     impl.updateMirrorSelected();
                     impl.maybeSelectOne = ulong(-1);
-                    impl.vtxAtMouse = ulong(-1);
+                    impl.updateVtxAtMouse(ulong(-1));
                     changed = true;
                 }
 
                 action.updateNewState();
                 incActionPush(action);
             } else {
-                auto action = new MeshAddAction(impl.getTarget().name, impl, mesh);
+                void addVertex(ref MeshVertex* vertex) {
+                    auto action = new MeshAddAction(impl.getTarget().name, impl, mesh);
 
-                ulong off = mesh.vertices.length;
-                if (impl.isOnMirror(impl.mousePos, impl.meshEditAOE)) {
-                    impl.placeOnMirror(impl.mousePos, impl.meshEditAOE);
-                } else {
-                    impl.foreachMirror((uint axis) {
-                        MeshVertex* vertex = new MeshVertex(impl.mirror(axis, impl.mousePos));
-                        action.addVertex(vertex);
-                    });
+                    ulong off = mesh.vertices.length;
+                    if (impl.isOnMirror(impl.mousePos, impl.meshEditAOE)) {
+                        impl.placeOnMirror(impl.mousePos, impl.meshEditAOE);
+                    } else {
+                        impl.foreachMirror((uint axis) {
+                            vertex = new MeshVertex(impl.mirror(axis, impl.mousePos));
+                            action.addVertex(vertex);
+                        });
+                    }
+                    impl.refreshMesh();
+                    impl.vertexMapDirty = true;
+                    if (io.KeyCtrl) impl.selectOne(mesh.vertices.length - 1);
+                    else impl.selectOne(off);
+                    changed = true;
+
+                    action.updateNewState();
+                    incActionPush(action);
                 }
-                impl.refreshMesh();
-                impl.vertexMapDirty = true;
-                if (io.KeyCtrl) impl.selectOne(mesh.vertices.length - 1);
-                else impl.selectOne(off);
-                changed = true;
 
-                action.updateNewState();
-                incActionPush(action);
+                // connect if there is a selected vertex
+                void connectVertex(ref MeshVertex* vertex) {
+                    if (vertex is null) return;
+
+                    auto prevMouse = impl.getVerticesByIndex([impl.prevVtxAtMouse])[0];
+                    auto action = new MeshConnectAction(impl.getTarget().name, impl, mesh);
+                    impl.foreachMirror((uint axis) {
+                        MeshVertex* mPrev = impl.mirrorVertex(axis, prevMouse);
+                        MeshVertex* mSel  = impl.mirrorVertex(axis, vertex);
+
+                        if (mPrev !is null && mSel !is null) {
+                            action.connect(mPrev, mSel);
+                        }
+                    });
+                    impl.refreshMesh();
+                    action.updateNewState();
+                    incActionPush(action);
+
+                    changed = true;
+                }
+
+                MeshVertex* vertex;
+                addVertex(vertex);
+                if (autoConnect)
+                    connectVertex(vertex);
             }
         }
 
@@ -424,6 +453,13 @@ class PointTool : NodeSelect {
         return changed;
     }
 
+    bool isAutoConnect() {
+        return autoConnect;
+    }
+
+    void setAutoConnect(bool autoConnect) {
+        this.autoConnect = autoConnect;
+    }
 }
 
 class ToolInfoImpl(T: PointTool) : ToolInfoBase!(T) {
@@ -433,4 +469,25 @@ class ToolInfoImpl(T: PointTool) : ToolInfoBase!(T) {
     string icon() { return ""; }
     override
     string description() { return _("Vertex Tool"); }
+
+    override
+    bool displayToolOptions(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) { 
+        if (deformOnly) {
+
+        } else {
+            auto pointTool = cast(PointTool)(editors.length == 0 ? null: editors.values()[0].getTool());
+            igBeginGroup();
+                if (incButtonColored("", ImVec2(0, 0), (pointTool !is null && !pointTool.isAutoConnect())? ImVec4.init : ImVec4(0.6, 0.6, 0.6, 1))) {
+                foreach (e; editors) {
+                    auto pt = cast(PointTool)(e.getTool());
+                    if (pt !is null)
+                        pt.setAutoConnect(!pt.isAutoConnect());
+                }
+                }
+                incTooltip(_("Auto connect vertices"));
+            igEndGroup();
+        }
+
+        return false;
+    }
 }

--- a/source/creator/viewport/common/mesheditor/tools/select.d
+++ b/source/creator/viewport/common/mesheditor/tools/select.d
@@ -58,7 +58,7 @@ class NodeSelect : Tool, Draggable {
             impl.mousePos = -impl.mousePos;
         }
 
-        impl.vtxAtMouse = impl.getVertexFromPoint(impl.mousePos);
+        impl.updateVtxAtMouse(impl.getVertexFromPoint(impl.mousePos));
 
         return 0;
     }

--- a/source/creator/viewport/vertex/package.d
+++ b/source/creator/viewport/vertex/package.d
@@ -190,6 +190,9 @@ void incViewportVertexOptions() {
             incTooltip(_("Auto Meshing Options"));
         igEndGroup();
 
+        igSameLine(0, 4);
+
+        editor.displayToolOptions();
     igPopStyleVar(2);
 }
 


### PR DESCRIPTION
* Introduced `prevVtxAtMouse` variable to track the last clicked vertex.
* Replaced direct assignment to `vtxAtMouse` with the `updateVtxAtMouse` function.
* Added a new `autoConnect` feature in `point.d` to automatically connect vertices when adding a new vertex.