### PR TITLE
Experimental: Save CPU When Losing Focus

### DIFF
--- a/source/creator/core/package.d
+++ b/source/creator/core/package.d
@@ -690,6 +690,12 @@ void incHandleEvent(SDL_Event *event) {
                 incSDLState = SDLEventState.WaitMode;
             if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
                 incSDLState = SDLEventState.PollMode;
+
+            // we can see the source code for this in imgui_impl_sdl2.cpp:ImGui_ImplSDL2_ProcessEvent()
+            // https://github.com/ocornut/imgui/blob/master/backends/imgui_impl_sdl2.cpp
+            // imgui will handle SDL_WINDOWEVENT, so we need to pass it to imgui
+            // incGLBackendProcessEvent() would invoke ImGui_ImplSDL2_ProcessEvent()
+            incGLBackendProcessEvent(event);
             break;
 
         default:

--- a/source/creator/windows/settings.d
+++ b/source/creator/windows/settings.d
@@ -152,6 +152,16 @@ protected:
                             }
                         endSection();
 
+                        beginSection(__("Performance"));
+                            bool renderOnFocusOnly = incSettingsGet!bool("RenderOnFocusOnly", true);
+                            if (igCheckbox(__("Render Only When Window Focused"), &renderOnFocusOnly)) {
+                                incSettingsSet("RenderOnFocusOnly", renderOnFocusOnly);
+                            }
+                            incTooltip(_("Stops rendering when you switch to other windows, saving CPU usage. " ~
+                                         "If you experience lag while recording or exporting videos," ~
+                                         "try turning off this feature."));
+                        endSection();
+
                         version(linux) {
                             beginSection(__("Linux Tweaks"));
                                 bool disableCompositor = incSettingsGet!bool("DisableCompositor");


### PR DESCRIPTION
**TL;DR:** Refactor event handling and add performance option

This update saves power without requiring changes to animation and physics animations.

* Refactored the event handling in the `incBeginLoop` function to use a state machine for managing poll and wait modes, reducing CPU usage when the application is not focused.
* Added a new performance option in the settings window called `Render Only When Window Focused`.  Enabling this option stops rendering when the window loses focus, further reducing CPU usage.
* This feature is enabled by default

Related issue: https://github.com/nijigenerate/nijigenerate/issues/21