### PR TITLE
Remove material icons from translatable strings.

### DIFF
--- a/source/creator/viewport/model/package.d
+++ b/source/creator/viewport/model/package.d
@@ -20,11 +20,25 @@ import inochi2d;
 import bindbc.imgui;
 import i18n;
 import std.stdio;
+import std.string : toStringz;
 
 private {
     Part[] foundParts;
 
     enum ENTRY_SIZE = 48;
+
+    bool viewportModel_stringLoaded = false;
+    const(char)* viewportModel_copyMeshString;
+    const(char)* viewportModel_editMeshString;
+
+    pragma(inline)
+    void incViewportModelLoadStrings() {
+        if(!viewportModel_stringLoaded){
+            viewportModel_copyMeshString = (" " ~ _("Copy Mesh")).toStringz();
+            viewportModel_editMeshString = (" " ~ _("Edit Mesh")).toStringz();
+            viewportModel_stringLoaded = true;
+        }
+    }
 }
 
 /** 
@@ -156,7 +170,8 @@ void incViewportModelConfirmBar() {
 
     igPushStyleVar(ImGuiStyleVar.FramePadding, ImVec2(16, 4));
         if (Drawable node = cast(Drawable)incSelectedNode()) {
-            const(char)* text = incHasDragDrop("_PUPPETNTREE") ? __(" Copy Mesh") : __(" Edit Mesh");
+            incViewportModelLoadStrings();
+            const(char)* text = incHasDragDrop("_PUPPETNTREE") ? viewportModel_copyMeshString : viewportModel_editMeshString;
             
             if (igButton(text, ImVec2(0, 26))) {
                 incVertexEditStartEditing(node);

--- a/source/creator/viewport/vertex/package.d
+++ b/source/creator/viewport/vertex/package.d
@@ -27,6 +27,20 @@ private {
         new GridAutoMeshProcessor()
     ];
     AutoMeshProcessor activeProcessor = null;
+
+    bool viewportVertex_stringLoaded = false;
+    const(char)* viewportVertex_applyString;
+    const(char)* viewportVertex_cancelString;
+
+    pragma(inline)
+    void incviewportVertexLoadStrings() {
+        if(!viewportVertex_stringLoaded){
+            viewportVertex_applyString = (" " ~ _("Apply")).toStringz();
+            viewportVertex_cancelString = (" " ~ _("Cancel")).toStringz();
+            viewportVertex_stringLoaded = true;
+        }
+    }
+
 }
 
 void incViewportVertexInspector(Drawable node) {
@@ -200,8 +214,9 @@ void incViewportVertexOptions() {
 
 void incViewportVertexConfirmBar() {
     auto target = editor.getTargets();
+    incviewportVertexLoadStrings();
     igPushStyleVar(ImGuiStyleVar.FramePadding, ImVec2(16, 4));
-        if (igButton(__(" Apply"), ImVec2(0, 26))) {
+        if (igButton(viewportVertex_applyString, ImVec2(0, 26))) {
             if (incMeshEditGetIsApplySafe()) {
                 incMeshEditApply();
             } else {
@@ -224,7 +239,7 @@ void incViewportVertexConfirmBar() {
         
         igSameLine(0, 0);
 
-        if (igButton(__(" Cancel"), ImVec2(0, 26))) {
+        if (igButton(viewportVertex_cancelString, ImVec2(0, 26))) {
             if (igGetIO().KeyShift) {
                 incMeshEditReset();
             } else {

--- a/source/creator/windows/kramerge.d
+++ b/source/creator/windows/kramerge.d
@@ -239,7 +239,7 @@ private:
             igPushID(cast(int)i);
                 const(char)* displayName = layer.layerName;
                 if (layer.replaceTexture) {
-                    displayName = _("%s  %s").format(layer.layer.name, layer.node.name).toStringz;
+                    displayName = "%s  %s".format(layer.layer.name, layer.node.name).toStringz;
                 }
 
                 if (layer.ignore) incTextDisabled("");

--- a/source/creator/windows/psdmerge.d
+++ b/source/creator/windows/psdmerge.d
@@ -235,7 +235,7 @@ private:
             igPushID(cast(int)i);
                 const(char)* displayName = layer.layerName;
                 if (layer.replaceTexture) {
-                    displayName = _("%s  %s").format(layer.layer.name, layer.node.name).toStringz;
+                    displayName = "%s  %s".format(layer.layer.name, layer.node.name).toStringz;
                 }
 
                 if (layer.ignore) incTextDisabled("");

--- a/tl/template.pot
+++ b/tl/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-15 23:19+0200\n"
+"POT-Creation-Date: 2024-09-16 01:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,16 +110,6 @@ msgstr ""
 #: source/creator/actions/mesh.d:489 source/creator/actions/mesh.d:497
 #, c-format
 msgid "%s: vertex was translated."
-msgstr ""
-
-#: source/creator/actions/mesheditor.d:157
-#, c-format
-msgid "%s->Edited deformation of %s."
-msgstr ""
-
-#: source/creator/actions/mesheditor.d:164
-#, c-format
-msgid "%s->deformation of %s was edited."
 msgstr ""
 
 #. Enforce reparenting rules
@@ -224,6 +214,16 @@ msgstr ""
 msgid "Parameter %s was added"
 msgstr ""
 
+#: source/creator/actions/mesheditor.d:157
+#, c-format
+msgid "%s->Edited deformation of %s."
+msgstr ""
+
+#: source/creator/actions/mesheditor.d:164
+#, c-format
+msgid "%s->deformation of %s was edited."
+msgstr ""
+
 #: source/creator/core/dpi.d:54 source/creator/core/dpi.d:58
 msgid "100% (Locked)"
 msgstr ""
@@ -265,17 +265,15 @@ msgid ""
 "Error message: "
 msgstr ""
 
-#. Also handle NFS or I/O errors
 #. Write error
+#. Also handle NFS or I/O errors
 #: source/creator/core/settings.d:36 source/creator/io/kra.d:278
-#: source/creator/io/package.d:194 source/creator/io/package.d:195
-#: source/creator/io/psd.d:271 source/creator/package.d:249
-#: source/creator/package.d:307 source/creator/package.d:372
-#: source/creator/panels/inspector.d:640 source/creator/panels/inspector.d:659
-#: source/creator/panels/inspector.d:660 source/creator/panels/inspector.d:671
+#: source/creator/io/psd.d:271 source/creator/io/package.d:194
+#: source/creator/io/package.d:195 source/creator/panels/inspector.d:640
+#: source/creator/panels/inspector.d:659 source/creator/panels/inspector.d:660
+#: source/creator/panels/inspector.d:671 source/creator/panels/viewport.d:257
 #: source/creator/panels/nodes.d:406 source/creator/panels/nodes.d:439
-#: source/creator/panels/viewport.d:257
-#: source/creator/viewport/vertex/package.d:387
+#: source/creator/viewport/vertex/package.d:402
 #: source/creator/widgets/mainmenu.d:243 source/creator/widgets/mainmenu.d:478
 #: source/creator/windows/imgexport.d:144
 #: source/creator/windows/inpexport.d:217
@@ -286,7 +284,8 @@ msgstr ""
 #: source/creator/windows/videoexport.d:148
 #: source/creator/windows/videoexport.d:293
 #: source/creator/windows/videoexport.d:303
-#: source/creator/windows/videoexport.d:311
+#: source/creator/windows/videoexport.d:311 source/creator/package.d:249
+#: source/creator/package.d:307 source/creator/package.d:372
 msgid "Error"
 msgstr ""
 
@@ -302,6 +301,10 @@ msgstr ""
 #: source/creator/io/imageexport.d:15
 #, c-format
 msgid "%s failed to export with error (%s)..."
+msgstr ""
+
+#: source/creator/io/videoexport.d:65
+msgid "Automatic"
 msgstr ""
 
 #. If this is executed it's a bug, using enforce here to prevent infinite loop.
@@ -335,6 +338,13 @@ msgid ""
 "%s"
 msgstr ""
 
+#: source/creator/io/psd.d:271
+#, c-format
+msgid ""
+"An error occured during PSD import:\n"
+"%s"
+msgstr ""
+
 #: source/creator/io/package.d:194 source/creator/panels/inspector.d:659
 #: source/creator/panels/inspector.d:671 source/creator/panels/viewport.d:257
 #, c-format
@@ -350,59 +360,6 @@ msgid ""
 "Would you like to keep the folder structure of the imported file?\n"
 "\n"
 "You can change the default behaviour in the settings."
-msgstr ""
-
-#: source/creator/io/psd.d:271
-#, c-format
-msgid ""
-"An error occured during PSD import:\n"
-"%s"
-msgstr ""
-
-#: source/creator/io/videoexport.d:65
-msgid "Automatic"
-msgstr ""
-
-#: source/creator/package.d:201
-msgid "New Project"
-msgstr ""
-
-#: source/creator/package.d:270
-#, c-format
-msgid "%s opened successfully."
-msgstr ""
-
-#: source/creator/package.d:303
-#, c-format
-msgid "%s saved successfully."
-msgstr ""
-
-#: source/creator/package.d:306
-#, c-format
-msgid "Failed to save %s"
-msgstr ""
-
-#: source/creator/package.d:342
-#, c-format
-msgid ""
-"The following errors occured during file loading\n"
-"%s"
-msgstr ""
-
-#: source/creator/package.d:352
-msgid "Folder import completed with errors..."
-msgstr ""
-
-#: source/creator/package.d:353
-msgid "Folder import completed..."
-msgstr ""
-
-#: source/creator/package.d:400
-msgid "Mipmap generation completed."
-msgstr ""
-
-#: source/creator/package.d:415
-msgid "Texture bleeding completed."
 msgstr ""
 
 #: source/creator/panels/actionhistory.d:26
@@ -424,19 +381,154 @@ msgstr ""
 msgid "History"
 msgstr ""
 
+#: source/creator/panels/logger.d:25
+msgid "Logger"
+msgstr ""
+
+#: source/creator/panels/scene.d:29
+msgid "Ambient Light"
+msgstr ""
+
+#: source/creator/panels/scene.d:38
+msgid "Scene"
+msgstr ""
+
+#: source/creator/panels/timeline.d:73
+msgid "Interpolation"
+msgstr ""
+
+#: source/creator/panels/timeline.d:74 source/creator/panels/parameters.d:547
+msgid "Nearest"
+msgstr ""
+
+#: source/creator/panels/timeline.d:77
+msgid "Stepped"
+msgstr ""
+
+#: source/creator/panels/timeline.d:80 source/creator/panels/parameters.d:553
+msgid "Linear"
+msgstr ""
+
+#: source/creator/panels/timeline.d:83 source/creator/panels/parameters.d:559
+msgid "Cubic"
+msgstr ""
+
+#: source/creator/panels/timeline.d:89
+msgid "Merge Mode"
+msgstr ""
+
+#: source/creator/panels/timeline.d:93 source/creator/windows/editanim.d:90
+msgid "Additive"
+msgstr ""
+
+#: source/creator/panels/timeline.d:96
+msgid "Multiplicative"
+msgstr ""
+
+#: source/creator/panels/timeline.d:101
+msgid "Forced"
+msgstr ""
+
+#: source/creator/panels/timeline.d:107 source/creator/panels/animlist.d:52
+#: source/creator/panels/inspector.d:909 source/creator/panels/inspector.d:1113
+#: source/creator/panels/nodes.d:194 source/creator/panels/parameters.d:959
+#: source/creator/panels/parameters.d:1192
+msgid "Delete"
+msgstr ""
+
+#: source/creator/panels/timeline.d:211
+msgid "Lock playback to animation framerate"
+msgstr ""
+
+#: source/creator/panels/timeline.d:281
+msgid "Not in Animation Edit mode..."
+msgstr ""
+
+#: source/creator/panels/timeline.d:288
+msgid "Timeline"
+msgstr ""
+
+#: source/creator/panels/toolsettings.d:31
+msgid "Tool Settings"
+msgstr ""
+
+#. Appended to the name of a face tracking receiver
+#. in the Tracking settings panel
+#: source/creator/panels/tracking.d:32
+#, c-format
+msgid "%s Receiver"
+msgstr ""
+
+#: source/creator/panels/tracking.d:60
+msgid "A reciever which uses your phone and associated app to track your body"
+msgstr ""
+
+#: source/creator/panels/tracking.d:64
+msgid "Bind Address"
+msgstr ""
+
+#: source/creator/panels/tracking.d:73
+msgid ""
+"The IP address that the VMC binding server should listen on, default 0.0.0.0"
+msgstr ""
+
+#: source/creator/panels/tracking.d:76
+msgid "Port"
+msgstr ""
+
+#: source/creator/panels/tracking.d:85
+msgid "The port that the VMC binding server should listen on, default 39540"
+msgstr ""
+
+#: source/creator/panels/tracking.d:88
+msgid "A reciever which uses the VTubeStudio iOS app"
+msgstr ""
+
+#: source/creator/panels/tracking.d:91
+msgid "iPhone IP"
+msgstr ""
+
+#: source/creator/panels/tracking.d:100
+msgid ""
+"The IP Address of your iPhone,\n"
+"You can find it in the VSeeFace Config panel in VTube Studio"
+msgstr ""
+
+#: source/creator/panels/tracking.d:103
+msgid "A receiver which uses OpenSeeFace application"
+msgstr ""
+
+#: source/creator/panels/tracking.d:105
+msgid "OSF Bind Address"
+msgstr ""
+
+#: source/creator/panels/tracking.d:116
+msgid "OSF Listen Port"
+msgstr ""
+
+#: source/creator/panels/tracking.d:128
+msgid "Tracking Bindings"
+msgstr ""
+
+#: source/creator/panels/tracking.d:133
+#, c-format
+msgid "%s bound to %s"
+msgstr ""
+
+#: source/creator/panels/tracking.d:148
+msgid "Not in Test Mode..."
+msgstr ""
+
+#: source/creator/panels/tracking.d:154
+msgid "Tracking"
+msgstr ""
+
 #: source/creator/panels/animlist.d:34 source/creator/panels/parameters.d:950
 msgid "Duplicate"
 msgstr ""
 
 #: source/creator/panels/animlist.d:49
 msgid "Edit..."
-msgstr ""
-
-#: source/creator/panels/animlist.d:52 source/creator/panels/inspector.d:909
-#: source/creator/panels/inspector.d:1113 source/creator/panels/nodes.d:194
-#: source/creator/panels/parameters.d:959
-#: source/creator/panels/parameters.d:1192 source/creator/panels/timeline.d:107
-msgid "Delete"
 msgstr ""
 
 #: source/creator/panels/animlist.d:88
@@ -1055,10 +1147,6 @@ msgstr ""
 msgid "Simple Physics"
 msgstr ""
 
-#: source/creator/panels/logger.d:25
-msgid "Logger"
-msgstr ""
-
 #: source/creator/panels/nodes.d:144
 msgid "Add"
 msgstr ""
@@ -1070,8 +1158,8 @@ msgstr ""
 #. Switches Inochi Creator over to Mesh Edit mode
 #. and selects the mesh that you had selected previously
 #. in Model Edit mode.
-#: source/creator/panels/nodes.d:184
-#: source/creator/viewport/model/package.d:186
+#: source/creator/panels/nodes.d:184 source/creator/viewport/model/package.d:38
+#: source/creator/viewport/model/package.d:201
 msgid "Edit Mesh"
 msgstr ""
 
@@ -1133,7 +1221,7 @@ msgid "Set to current"
 msgstr ""
 
 #: source/creator/panels/parameters.d:294
-#: source/creator/viewport/model/package.d:239
+#: source/creator/viewport/model/package.d:254
 msgid "Reset"
 msgstr ""
 
@@ -1195,18 +1283,6 @@ msgstr ""
 
 #: source/creator/panels/parameters.d:546
 msgid "Interpolation Mode"
-msgstr ""
-
-#: source/creator/panels/parameters.d:547 source/creator/panels/timeline.d:74
-msgid "Nearest"
-msgstr ""
-
-#: source/creator/panels/parameters.d:553 source/creator/panels/timeline.d:80
-msgid "Linear"
-msgstr ""
-
-#: source/creator/panels/parameters.d:559 source/creator/panels/timeline.d:83
-msgid "Cubic"
 msgstr ""
 
 #: source/creator/panels/parameters.d:569
@@ -1317,125 +1393,6 @@ msgstr ""
 
 #: source/creator/panels/parameters.d:1269
 msgid "Parameters"
-msgstr ""
-
-#: source/creator/panels/scene.d:29
-msgid "Ambient Light"
-msgstr ""
-
-#: source/creator/panels/scene.d:38
-msgid "Scene"
-msgstr ""
-
-#: source/creator/panels/timeline.d:73
-msgid "Interpolation"
-msgstr ""
-
-#: source/creator/panels/timeline.d:77
-msgid "Stepped"
-msgstr ""
-
-#: source/creator/panels/timeline.d:89
-msgid "Merge Mode"
-msgstr ""
-
-#: source/creator/panels/timeline.d:93 source/creator/windows/editanim.d:90
-msgid "Additive"
-msgstr ""
-
-#: source/creator/panels/timeline.d:96
-msgid "Multiplicative"
-msgstr ""
-
-#: source/creator/panels/timeline.d:101
-msgid "Forced"
-msgstr ""
-
-#: source/creator/panels/timeline.d:211
-msgid "Lock playback to animation framerate"
-msgstr ""
-
-#: source/creator/panels/timeline.d:281
-msgid "Not in Animation Edit mode..."
-msgstr ""
-
-#: source/creator/panels/timeline.d:288
-msgid "Timeline"
-msgstr ""
-
-#: source/creator/panels/toolsettings.d:31
-msgid "Tool Settings"
-msgstr ""
-
-#. Appended to the name of a face tracking receiver
-#. in the Tracking settings panel
-#: source/creator/panels/tracking.d:32
-#, c-format
-msgid "%s Receiver"
-msgstr ""
-
-#: source/creator/panels/tracking.d:60
-msgid "A reciever which uses your phone and associated app to track your body"
-msgstr ""
-
-#: source/creator/panels/tracking.d:64
-msgid "Bind Address"
-msgstr ""
-
-#: source/creator/panels/tracking.d:73
-msgid ""
-"The IP address that the VMC binding server should listen on, default 0.0.0.0"
-msgstr ""
-
-#: source/creator/panels/tracking.d:76
-msgid "Port"
-msgstr ""
-
-#: source/creator/panels/tracking.d:85
-msgid "The port that the VMC binding server should listen on, default 39540"
-msgstr ""
-
-#: source/creator/panels/tracking.d:88
-msgid "A reciever which uses the VTubeStudio iOS app"
-msgstr ""
-
-#: source/creator/panels/tracking.d:91
-msgid "iPhone IP"
-msgstr ""
-
-#: source/creator/panels/tracking.d:100
-msgid ""
-"The IP Address of your iPhone,\n"
-"You can find it in the VSeeFace Config panel in VTube Studio"
-msgstr ""
-
-#: source/creator/panels/tracking.d:103
-msgid "A receiver which uses OpenSeeFace application"
-msgstr ""
-
-#: source/creator/panels/tracking.d:105
-msgid "OSF Bind Address"
-msgstr ""
-
-#: source/creator/panels/tracking.d:116
-msgid "OSF Listen Port"
-msgstr ""
-
-#: source/creator/panels/tracking.d:128
-msgid "Tracking Bindings"
-msgstr ""
-
-#: source/creator/panels/tracking.d:133
-#, c-format
-msgid "%s bound to %s"
-msgstr ""
-
-#: source/creator/panels/tracking.d:148
-msgid "Not in Test Mode..."
-msgstr ""
-
-#: source/creator/panels/tracking.d:154
-msgid "Tracking"
 msgstr ""
 
 #. Use appropriate system method to notify user where crash dump is.
@@ -1559,14 +1516,6 @@ msgstr ""
 msgid "Y Scale"
 msgstr ""
 
-#: source/creator/viewport/common/mesheditor/package.d:282
-msgid "Reset selected"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/package.d:285
-msgid "Flip selected from mirror"
-msgstr ""
-
 #: source/creator/viewport/common/mesheditor/tools/brush.d:161
 #: source/creator/viewport/common/mesheditor/tools/pathdeform.d:216
 msgid "Deform"
@@ -1578,10 +1527,10 @@ msgstr ""
 #: source/creator/viewport/common/mesheditor/tools/grid.d:240
 #: source/creator/viewport/common/mesheditor/tools/grid.d:241
 #: source/creator/viewport/common/mesheditor/tools/grid.d:242
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:149
 #: source/creator/viewport/common/mesheditor/tools/pathdeform.d:216
 #: source/creator/viewport/common/mesheditor/tools/point.d:98
 #: source/creator/viewport/common/mesheditor/tools/point.d:340
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:149
 msgid "Left Mouse"
 msgstr ""
 
@@ -1651,53 +1600,6 @@ msgstr ""
 msgid "Grid Vertex Tool"
 msgstr ""
 
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:149
-msgid "Add Lasso Point"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:150
-msgid "Additive Selection"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:150
-#: source/creator/viewport/common/mesheditor/tools/pathdeform.d:223
-msgid "Shift"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:151
-msgid "Inverse Selection"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:151
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:152
-#: source/creator/viewport/common/mesheditor/tools/pathdeform.d:222
-msgid "Ctrl"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:152
-msgid "Remove Selection"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:153
-msgid "Delete Last Lasso Point"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:153
-msgid "Right Mouse"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:154
-msgid "Clear All Lasso Points"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:154
-msgid "ESC"
-msgstr ""
-
-#: source/creator/viewport/common/mesheditor/tools/lasso.d:246
-msgid "Lasso Selection"
-msgstr ""
-
 #: source/creator/viewport/common/mesheditor/tools/pathdeform.d:217
 #: source/creator/viewport/common/mesheditor/tools/pathdeform.d:220
 msgid "Switch Mode"
@@ -1720,8 +1622,19 @@ msgstr ""
 msgid "Toggle locked point"
 msgstr ""
 
+#: source/creator/viewport/common/mesheditor/tools/pathdeform.d:222
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:151
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:152
+msgid "Ctrl"
+msgstr ""
+
 #: source/creator/viewport/common/mesheditor/tools/pathdeform.d:223
 msgid "Move point along with the path"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/pathdeform.d:223
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:150
+msgid "Shift"
 msgstr ""
 
 #: source/creator/viewport/common/mesheditor/tools/pathdeform.d:415
@@ -1762,69 +1675,198 @@ msgstr ""
 msgid "Auto connect vertices"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:82
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:149
+msgid "Add Lasso Point"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:150
+msgid "Additive Selection"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:151
+msgid "Inverse Selection"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:152
+msgid "Remove Selection"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:153
+msgid "Delete Last Lasso Point"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:153
+msgid "Right Mouse"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:154
+msgid "Clear All Lasso Points"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:154
+msgid "ESC"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/tools/lasso.d:246
+msgid "Lasso Selection"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/package.d:282
+msgid "Reset selected"
+msgstr ""
+
+#: source/creator/viewport/common/mesheditor/package.d:285
+msgid "Flip selected from mirror"
+msgstr ""
+
+#: source/creator/viewport/model/package.d:37
+msgid "Copy Mesh"
+msgstr ""
+
+#: source/creator/viewport/model/package.d:96
 msgid "Z-Sort"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:82
+#: source/creator/viewport/model/package.d:96
 msgid "Size-Sort"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:92
+#: source/creator/viewport/model/package.d:106
 msgid "Focus Selected"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:140
+#: source/creator/viewport/model/package.d:154
 msgid "No parts found"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:159
-msgid " Copy Mesh"
-msgstr ""
-
-#: source/creator/viewport/model/package.d:159
-msgid " Edit Mesh"
-msgstr ""
-
-#: source/creator/viewport/model/package.d:167
+#: source/creator/viewport/model/package.d:182
 msgid "Copy Mesh Data"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:201
+#: source/creator/viewport/model/package.d:216
 msgid "Hide Vertices"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:201
+#: source/creator/viewport/model/package.d:216
 msgid "Show Vertices"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:207
+#: source/creator/viewport/model/package.d:222
 msgid "Hide Bounds"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:207
+#: source/creator/viewport/model/package.d:222
 msgid "Show Bounds"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:213
+#: source/creator/viewport/model/package.d:228
 msgid "Hide Orientation Gizmo"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:213
+#: source/creator/viewport/model/package.d:228
 msgid "Show Orientation Gizmo"
 msgstr ""
 
 #. Set clear color
-#: source/creator/viewport/model/package.d:228
+#: source/creator/viewport/model/package.d:243
 msgid "COLOR"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:243
+#: source/creator/viewport/model/package.d:258
 msgid "Background Color"
 msgstr ""
 
-#: source/creator/viewport/model/package.d:247
+#: source/creator/viewport/model/package.d:262
 msgid "Gizmos"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:38
+#: source/creator/viewport/vertex/package.d:238
+#: source/creator/windows/paramsplit.d:171
+msgid "Apply"
+msgstr ""
+
+#.
+#. Cancels the edited state for the axies points
+#: source/creator/viewport/vertex/package.d:39
+#: source/creator/viewport/vertex/package.d:255
+#: source/creator/widgets/dialog.d:142 source/creator/windows/flipconfig.d:479
+#: source/creator/windows/paramaxes.d:169
+#: source/creator/windows/videoexport.d:272
+msgid "Cancel"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:89
+msgid "Show Mesh Group Child Nodes Bounds"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:102
+msgid "Flip Horizontally"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:113
+msgid "Flip Vertically"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:123
+msgid "Mirror Horizontally"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:131
+msgid "Mirror Vertically"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:142
+msgid "Triangulate vertices"
+msgstr ""
+
+#. Button which bakes some auto generated content
+#. In this case, a mesh is baked from the triangulation.
+#: source/creator/viewport/vertex/package.d:149
+#: source/creator/viewport/vertex/package.d:194
+msgid "Bake"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:156
+msgid "Bakes the triangulation, applying it to the mesh."
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:160
+msgid "Triangulation Options"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:202
+msgid "Bakes the auto mesh."
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:206
+msgid "Auto Meshing Options"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:225
+msgid "Are you sure?"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:226
+msgid ""
+"The layout of the mesh has changed, all deformations to this mesh will be "
+"deleted if you continue."
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:322
+msgid "No Drawables"
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:323
+msgid ""
+"This meshgroup has no drawables to deform. To deform, replace the child with "
+"a meshgroup or other type."
+msgstr ""
+
+#: source/creator/viewport/vertex/package.d:402
+msgid ""
+"Cannot apply invalid mesh\n"
+"At least 3 vertices forming a triangle is needed."
 msgstr ""
 
 #: source/creator/viewport/package.d:301
@@ -1839,99 +1881,45 @@ msgstr ""
 msgid "Editing base transform..."
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:75
-msgid "Show Mesh Group Child Nodes Bounds"
+#: source/creator/widgets/modal/nagscreen.d:116
+#: source/creator/windows/videoexport.d:278
+msgid "Close"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:88
-msgid "Flip Horizontally"
+#: source/creator/widgets/toolbar.d:40
+msgid "Mirror View"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:99
-msgid "Flip Vertically"
+#: source/creator/widgets/toolbar.d:47
+msgid "Enable physics"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:109
-msgid "Mirror Horizontally"
+#: source/creator/widgets/toolbar.d:54
+msgid "Enable post processing"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:117
-msgid "Mirror Vertically"
+#: source/creator/widgets/toolbar.d:59
+msgid "Reset physics"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:128
-msgid "Triangulate vertices"
+#: source/creator/widgets/toolbar.d:66
+msgid "Configure Flip Pairings"
 msgstr ""
 
-#. Button which bakes some auto generated content
-#. In this case, a mesh is baked from the triangulation.
-#: source/creator/viewport/vertex/package.d:135
-#: source/creator/viewport/vertex/package.d:180
-msgid "Bake"
+#: source/creator/widgets/toolbar.d:75
+msgid "Reset parameters"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:142
-msgid "Bakes the triangulation, applying it to the mesh."
+#: source/creator/widgets/toolbar.d:95
+msgid "Edit Puppet"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:146
-msgid "Triangulation Options"
+#: source/creator/widgets/toolbar.d:100
+msgid "Edit Animation"
 msgstr ""
 
-#: source/creator/viewport/vertex/package.d:188
-msgid "Bakes the auto mesh."
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:192
-msgid "Auto Meshing Options"
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:204
-msgid " Apply"
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:210
-msgid "Are you sure?"
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:211
-msgid ""
-"The layout of the mesh has changed, all deformations to this mesh will be "
-"deleted if you continue."
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:223
-#: source/creator/windows/paramsplit.d:171
-msgid "Apply"
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:227
-msgid " Cancel"
-msgstr ""
-
-#.
-#. Cancels the edited state for the axies points
-#: source/creator/viewport/vertex/package.d:240
-#: source/creator/widgets/dialog.d:142 source/creator/windows/flipconfig.d:479
-#: source/creator/windows/paramaxes.d:169
-#: source/creator/windows/videoexport.d:272
-msgid "Cancel"
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:307
-msgid "No Drawables"
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:308
-msgid ""
-"This meshgroup has no drawables to deform. To deform, replace the child with "
-"a meshgroup or other type."
-msgstr ""
-
-#: source/creator/viewport/vertex/package.d:387
-msgid ""
-"Cannot apply invalid mesh\n"
-"At least 3 vertices forming a triangle is needed."
+#: source/creator/widgets/toolbar.d:105
+msgid "Test Puppet"
 msgstr ""
 
 #: source/creator/widgets/dialog.d:118
@@ -2311,59 +2299,18 @@ msgstr ""
 msgid "Request a Feature"
 msgstr ""
 
-#: source/creator/widgets/mainmenu.d:577 source/creator/windows/about.d:133
+#: source/creator/widgets/mainmenu.d:577 source/creator/windows/about.d:138
 msgid "About"
 msgstr ""
 
 #. Donate button
 #: source/creator/widgets/mainmenu.d:592 source/creator/widgets/mainmenu.d:615
-#: source/creator/windows/about.d:124
+#: source/creator/windows/about.d:128
 msgid "Donate"
 msgstr ""
 
 #: source/creator/widgets/mainmenu.d:619
 msgid "Support development via Patreon"
-msgstr ""
-
-#: source/creator/widgets/modal/nagscreen.d:116
-#: source/creator/windows/videoexport.d:278
-msgid "Close"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:40
-msgid "Mirror View"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:47
-msgid "Enable physics"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:54
-msgid "Enable post processing"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:59
-msgid "Reset physics"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:66
-msgid "Configure Flip Pairings"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:75
-msgid "Reset parameters"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:95
-msgid "Edit Puppet"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:100
-msgid "Edit Animation"
-msgstr ""
-
-#: source/creator/widgets/toolbar.d:105
-msgid "Test Puppet"
 msgstr ""
 
 #: source/creator/windows/autosave.d:45
@@ -2592,11 +2539,6 @@ msgstr ""
 msgid "Export Options"
 msgstr ""
 
-#: source/creator/windows/kramerge.d:242 source/creator/windows/psdmerge.d:238
-#, c-format
-msgid "%s  %s"
-msgstr ""
-
 #: source/creator/windows/kramerge.d:285 source/creator/windows/psdmerge.d:281
 msgid "Ignore"
 msgstr ""
@@ -2688,120 +2630,6 @@ msgstr ""
 #: source/creator/windows/rename.d:64
 #, c-format
 msgid "Rename %s..."
-msgstr ""
-
-#: source/creator/windows/settings.d:81 source/creator/windows/settings.d:112
-msgid "Look and Feel"
-msgstr ""
-
-#: source/creator/windows/settings.d:89
-msgid "Accessbility"
-msgstr ""
-
-#: source/creator/windows/settings.d:93
-msgid "File Handling"
-msgstr ""
-
-#: source/creator/windows/settings.d:113 source/creator/windows/welcome.d:175
-msgid "Color Theme"
-msgstr ""
-
-#: source/creator/windows/settings.d:113 source/creator/windows/settings.d:114
-#: source/creator/windows/welcome.d:175 source/creator/windows/welcome.d:176
-msgid "Dark"
-msgstr ""
-
-#: source/creator/windows/settings.d:113 source/creator/windows/settings.d:115
-#: source/creator/windows/welcome.d:175 source/creator/windows/welcome.d:177
-msgid "Light"
-msgstr ""
-
-#: source/creator/windows/settings.d:121 source/creator/windows/welcome.d:161
-msgid "Language"
-msgstr ""
-
-#: source/creator/windows/settings.d:140 source/creator/windows/welcome.d:187
-msgid "UI Scale"
-msgstr ""
-
-#: source/creator/windows/settings.d:150
-msgid "Max Undo History"
-msgstr ""
-
-#: source/creator/windows/settings.d:156
-msgid "Linux Tweaks"
-msgstr ""
-
-#: source/creator/windows/settings.d:158
-msgid "Disable Compositor"
-msgstr ""
-
-#: source/creator/windows/settings.d:165
-msgid "Accessibility"
-msgstr ""
-
-#: source/creator/windows/settings.d:167
-msgid "Use OpenDyslexic Font"
-msgstr ""
-
-#: source/creator/windows/settings.d:171
-msgid "Use the OpenDyslexic font for Latin text characters."
-msgstr ""
-
-#: source/creator/windows/settings.d:174
-msgid "Scroll to armed parameter"
-msgstr ""
-
-#: source/creator/windows/settings.d:177
-msgid "Enable automatic scrolling to the top of the parameters list."
-msgstr ""
-
-#: source/creator/windows/settings.d:183
-msgid "Enable Autosaves"
-msgstr ""
-
-#: source/creator/windows/settings.d:188
-msgid "Save Interval (Minutes)"
-msgstr ""
-
-#: source/creator/windows/settings.d:193
-msgid "Maximum Autosaves"
-msgstr ""
-
-#: source/creator/windows/settings.d:198
-msgid "Import behaviour"
-msgstr ""
-
-#: source/creator/windows/settings.d:200
-msgid "Always ask"
-msgstr ""
-
-#: source/creator/windows/settings.d:201
-msgid "Preserve"
-msgstr ""
-
-#: source/creator/windows/settings.d:202
-msgid "Don't preserve"
-msgstr ""
-
-#: source/creator/windows/settings.d:208
-msgid "Preserve structure"
-msgstr ""
-
-#: source/creator/windows/settings.d:222
-msgid "Zoom Mode"
-msgstr ""
-
-#: source/creator/windows/settings.d:232
-msgid "Zoom Speed"
-msgstr ""
-
-#: source/creator/windows/settings.d:251 source/creator/windows/welcome.d:199
-msgid "Inochi Creator needs to be restarted for some changes to take effect."
-msgstr ""
-
-#: source/creator/windows/settings.d:259
-msgid "Done"
 msgstr ""
 
 #: source/creator/windows/texviewer.d:47
@@ -2901,6 +2729,32 @@ msgstr ""
 msgid "Quick Setup"
 msgstr ""
 
+#: source/creator/windows/welcome.d:161 source/creator/windows/settings.d:121
+msgid "Language"
+msgstr ""
+
+#: source/creator/windows/welcome.d:175 source/creator/windows/settings.d:113
+msgid "Color Theme"
+msgstr ""
+
+#: source/creator/windows/welcome.d:175 source/creator/windows/welcome.d:176
+#: source/creator/windows/settings.d:113 source/creator/windows/settings.d:114
+msgid "Dark"
+msgstr ""
+
+#: source/creator/windows/welcome.d:175 source/creator/windows/welcome.d:177
+#: source/creator/windows/settings.d:113 source/creator/windows/settings.d:115
+msgid "Light"
+msgstr ""
+
+#: source/creator/windows/welcome.d:187 source/creator/windows/settings.d:140
+msgid "UI Scale"
+msgstr ""
+
+#: source/creator/windows/welcome.d:199 source/creator/windows/settings.d:251
+msgid "Inochi Creator needs to be restarted for some changes to take effect."
+msgstr ""
+
 #: source/creator/windows/welcome.d:212
 msgid "Next"
 msgstr ""
@@ -2955,4 +2809,134 @@ msgstr ""
 
 #: source/creator/windows/welcome.d:357
 msgid "Inochi Creator Start"
+msgstr ""
+
+#: source/creator/windows/settings.d:81 source/creator/windows/settings.d:112
+msgid "Look and Feel"
+msgstr ""
+
+#: source/creator/windows/settings.d:89
+msgid "Accessbility"
+msgstr ""
+
+#: source/creator/windows/settings.d:93
+msgid "File Handling"
+msgstr ""
+
+#: source/creator/windows/settings.d:150
+msgid "Max Undo History"
+msgstr ""
+
+#: source/creator/windows/settings.d:156
+msgid "Linux Tweaks"
+msgstr ""
+
+#: source/creator/windows/settings.d:158
+msgid "Disable Compositor"
+msgstr ""
+
+#: source/creator/windows/settings.d:165
+msgid "Accessibility"
+msgstr ""
+
+#: source/creator/windows/settings.d:167
+msgid "Use OpenDyslexic Font"
+msgstr ""
+
+#: source/creator/windows/settings.d:171
+msgid "Use the OpenDyslexic font for Latin text characters."
+msgstr ""
+
+#: source/creator/windows/settings.d:174
+msgid "Scroll to armed parameter"
+msgstr ""
+
+#: source/creator/windows/settings.d:177
+msgid "Enable automatic scrolling to the top of the parameters list."
+msgstr ""
+
+#: source/creator/windows/settings.d:183
+msgid "Enable Autosaves"
+msgstr ""
+
+#: source/creator/windows/settings.d:188
+msgid "Save Interval (Minutes)"
+msgstr ""
+
+#: source/creator/windows/settings.d:193
+msgid "Maximum Autosaves"
+msgstr ""
+
+#: source/creator/windows/settings.d:198
+msgid "Import behaviour"
+msgstr ""
+
+#: source/creator/windows/settings.d:200
+msgid "Always ask"
+msgstr ""
+
+#: source/creator/windows/settings.d:201
+msgid "Preserve"
+msgstr ""
+
+#: source/creator/windows/settings.d:202
+msgid "Don't preserve"
+msgstr ""
+
+#: source/creator/windows/settings.d:208
+msgid "Preserve structure"
+msgstr ""
+
+#: source/creator/windows/settings.d:222
+msgid "Zoom Mode"
+msgstr ""
+
+#: source/creator/windows/settings.d:232
+msgid "Zoom Speed"
+msgstr ""
+
+#: source/creator/windows/settings.d:259
+msgid "Done"
+msgstr ""
+
+#: source/creator/package.d:201
+msgid "New Project"
+msgstr ""
+
+#: source/creator/package.d:270
+#, c-format
+msgid "%s opened successfully."
+msgstr ""
+
+#: source/creator/package.d:303
+#, c-format
+msgid "%s saved successfully."
+msgstr ""
+
+#: source/creator/package.d:306
+#, c-format
+msgid "Failed to save %s"
+msgstr ""
+
+#: source/creator/package.d:342
+#, c-format
+msgid ""
+"The following errors occured during file loading\n"
+"%s"
+msgstr ""
+
+#: source/creator/package.d:352
+msgid "Folder import completed with errors..."
+msgstr ""
+
+#: source/creator/package.d:353
+msgid "Folder import completed..."
+msgstr ""
+
+#: source/creator/package.d:400
+msgid "Mipmap generation completed."
+msgstr ""
+
+#: source/creator/package.d:415
+msgid "Texture bleeding completed."
 msgstr ""


### PR DESCRIPTION
Removed some icons from translatable strings so that they don't get changed through the translation process.

This changes impact the following views

Mesh Edit/Copy
![image](https://github.com/user-attachments/assets/3bf1ff9d-d2d9-4939-88be-41d1fafb2f86)
![image](https://github.com/user-attachments/assets/42fdf478-dc6c-42ae-b3b1-19c3654f152f)

Apply/Cancel buttons from the Mesh Edit view
![image](https://github.com/user-attachments/assets/50e1652b-b182-4232-b498-2bb97ed1dc4d)

Removed arrow asociation string from PSD/KRA merge view
![image](https://github.com/user-attachments/assets/d59224ca-9309-476e-a8ca-4b42567cc4b7)

Also re-ran the `genpot.sh` script to regenerate the strings.