### PR TITLE
Support space key to move canvas

### DIFF
--- a/source/creator/viewport/package.d
+++ b/source/creator/viewport/package.d
@@ -867,7 +867,11 @@ private {
         float uiScale = incGetUIScale();
         
         // HANDLE MOVE VIEWPORT
-        if (!isMovingViewport && io.MouseDown[1] && incInputIsDragRequested()) {
+        bool mouseRightStart = io.MouseDown[1] && incInputIsDragRequested();
+        bool mouseRightEnd = !io.MouseDown[1];
+        bool spaceStart = io.KeysDown[ImGuiKey.Space];
+        bool spaceEnd = !io.KeysDown[ImGuiKey.Space];
+        if (!isMovingViewport && (mouseRightStart || spaceStart)) {
             isMovingViewport = true;
             sx = io.MousePos.x;
             sy = io.MousePos.y;
@@ -875,7 +879,7 @@ private {
             csy = camera.position.y;
         }
 
-        if (isMovingViewport && !io.MouseDown[1]) {
+        if (isMovingViewport && (mouseRightEnd && spaceEnd)) {
             isMovingViewport = false;
         }
 


### PR DESCRIPTION
* Most drawing software such as medibang, gimp, krita support the space key to move the canvas, so it should be implemented in creator

related #480 