### PR TITLE
Restore Catch Exception Logic

### DIFF
--- a/source/creator/package.d
+++ b/source/creator/package.d
@@ -231,7 +231,6 @@ bool incOpenProject(string path) {
 */
 bool incOpenProject(string mainPath, string backupPath) {
     import std.path : setExtension, baseName;
-    import std.file : FileException;
 
     incClearImguiData();
     
@@ -244,9 +243,15 @@ bool incOpenProject(string mainPath, string backupPath) {
         } else {
             puppet = inLoadPuppet!ExPuppet(mainPath);
         }
-    } catch (FileException ex) {
-        // Also handle NFS or I/O errors
-        incDialog(__("Error"), ex.msg);
+    } catch (Exception ex) {
+        // for user, we should show a dialog and dump the thrown stack
+        import std.file : write;
+        import creator.utils.crashdump;
+        string path = genCrashDumpPath("inochi-creator-runtime-error");
+        write(path, genCrashDump(ex));
+
+        // show dialog
+        incDialog(__("Error"), ex.msg ~ "\n\n" ~ _("Please report this file to the developers:\n\n%s").format(path));
         return false;
     }
 

--- a/source/creator/utils/crashdump.d
+++ b/source/creator/utils/crashdump.d
@@ -53,12 +53,15 @@ string getCrashDumpDir() {
     else return expandTilde("~");
 }
 
-
+string genCrashDumpPath(string filename) {
+    import std.datetime;
+    return buildPath(getCrashDumpDir(), filename ~ "-" ~ Clock.currTime.toISOString() ~ ".txt");
+}
 
 void crashdump(T...)(Throwable throwable, T state) {
 
     // Write crash dump to disk
-    write(buildPath(getCrashDumpDir(), "inochi-creator-crashdump.txt"), genCrashDump!T(throwable, state));
+    write(genCrashDumpPath("inochi-creator-crashdump"), genCrashDump!T(throwable, state));
 
     // Use appropriate system method to notify user where crash dump is.
     version(OSX) writeln(_("\n\n\n===   Inochi Creator has crashed   ===\nPlease send us the inochi-creator-crashdump.txt file in ~/Library/Logs\nAttach the file as a git issue @ https://github.com/Inochi2D/inochi-creator/issues"));


### PR DESCRIPTION
In any case, we should not crash at the user end
This commit reverts the previous FileException only error handling And add runtime error dump to let users know that they should report to developers