### PR TITLE
Experimental: Preview and Select Node via Mouse Hover in Viewport

### DIFF
--- a/source/creator/panels/viewport.d
+++ b/source/creator/panels/viewport.d
@@ -186,6 +186,9 @@ protected:
             }
             igPopStyleVar();
 
+            import creator.viewport.model : incSelectIO;
+            incSelectIO();
+
             igPushStyleVar(ImGuiStyleVar.FrameBorderSize, 0);
                 incBeginViewportToolArea("ToolArea", ImGuiDir.Left);
                     igPushStyleVar_Vec2(ImGuiStyleVar.FramePadding, ImVec2(6, 6));


### PR DESCRIPTION
This experiment aims to introduce a feature that allows users to preview and select nodes by hovering their mouse over them in the viewport. This will provide a more intuitive and efficient way of interacting with nodes.

Todo
* [ ] To address potential performance concerns, the hover-based node selection feature will be disabled by default until a high-performance algorithm is implemented.

Users can enable it in the settings as an experimental option, allowing for testing and feedback while minimizing performance impacts.

https://github.com/user-attachments/assets/e071e916-54a5-4e2a-9ff5-88f802fb4dd2

