### PR TITLE
Duplication

### DIFF
--- a/source/creator/actions/node.d
+++ b/source/creator/actions/node.d
@@ -332,6 +332,73 @@ void incAddChildWithHistory(Node n, Node to, string name=null) {
     incActivePuppet().rescanNodes();
 }
 
+void recursiveDuplicate(Node n, Node to){
+    Node x;
+
+    if ((cast(Part) n) is null) {
+        
+    if ((cast(Composite) n) is null) {
+    
+    if ((cast(MeshGroup) n) is null) {
+        
+    if ((cast(SimplePhysics) n) is null) {
+        
+    if ((cast(Camera) n) is null) {
+        x = new Node(to);
+        
+    }//Lets not duplicate cameras for now
+    else return;
+    }else {
+        SimplePhysics c = cast(SimplePhysics) n;
+        SimplePhysics p = new SimplePhysics(to);
+        p.param(c.param());
+        p.modelType_ = c.modelType_;
+        p.mapMode = c.mapMode;
+        p.localOnly = c.localOnly;
+        p.gravity = c.gravity;
+        p.length = c.length;
+        p.frequency = c.frequency;
+        p.angleDamping = c.angleDamping;
+        p.lengthDamping = c.lengthDamping;
+        p.outputScale = c.outputScale;
+        p.output = c.output;
+    }
+    }
+    }else{
+        //Composite c = cast(Composite) n;
+        Composite p = new Composite(to);
+        x=p;
+
+    }
+    }else{
+        Part c = cast(Part) n;
+        Part p = new Part(c.getMesh(),c.textures,to); 
+        p.textureIds = c.textureIds;
+        p.tint = c.tint;
+        p.screenTint = c.screenTint;
+        p.emissionStrength = c.emissionStrength;
+        p.blendingMode = c.blendingMode;
+        p.opacity = c.opacity;
+        p.maskAlphaThreshold = c.maskAlphaThreshold;
+        p.masks = dup(c.masks);
+        x = p;
+    }
+    x.name = n.name;
+    x.enabled = n.enabled;
+    x.globalTransform = n.globalTransform;
+    x.localTransform = n.localTransform;
+    x.zSort = n.zSort;
+
+ 
+    foreach (child; n.children())
+    {
+        recursiveDuplicate(child,x);
+    }
+    // not an object of `ChildClass`
+
+    
+}
+
 GroupAction incDeleteMaskOfNode(Node n, GroupAction group = null) {
     auto removedDrawables = incActivePuppet().findNodesType!Drawable(n);
     auto parts = incActivePuppet().findNodesType!Part(incActivePuppet().root);

--- a/source/creator/atlas/atlas.d
+++ b/source/creator/atlas/atlas.d
@@ -119,6 +119,7 @@ public:
 
     /**
         Mappings from part UUID to an area on the atlas
+        Attempting to chanfge this to texture UUID instead
     */
     rect[uint] mappings;
 
@@ -144,6 +145,7 @@ public:
         UVs should be stretched to cover this area.
     */
     bool pack(Part p, float fscale=1) {
+        if ((p.textures[0].getRuntimeUUID() in mappings) is null){
         auto mesh = p.getMesh();
         vec2 textureStartOffset = vec2(0, 0);
         vec2 textureEndOffset   = vec2(0, 0);
@@ -206,10 +208,11 @@ public:
                 // where is the calculated texture boundary #2, specifying the area which texture is copied. (always between 0..1 in UV position)
                 rect where = rect(atlasArea.x+textureStartOffset.x+padding, atlasArea.y+textureStartOffset.y+padding, 
                                   atlasArea.z-(padding*2)-textureStartOffset.x - textureEndOffset.x, atlasArea.w-(padding*2)-textureStartOffset.y - textureEndOffset.y);
-                mappings[p.uuid] = rect(atlasArea.x+padding, atlasArea.y+padding, atlasArea.z-padding*2, atlasArea.w-padding*2);
+                mappings[texture.getRuntimeUUID()] = rect(atlasArea.x+padding, atlasArea.y+padding, atlasArea.z-padding*2, atlasArea.w-padding*2);
                 renderToTexture(texture, where, uvRect);
                 inBlendModeBarrier(BlendMode.Normal);
             }
+        }
         }
         return true;
     }

--- a/source/creator/io/inpexport.d
+++ b/source/creator/io/inpexport.d
@@ -334,7 +334,7 @@ void incINPExportFinalizePacking(ref Puppet source, Atlas[] atlasses) {
         foreach(Atlas atlas; atlasses) {
             
             // Look for our part in the atlas
-            if (part.uuid in atlas.mappings) {
+            if (part.textures[0].getRuntimeUUID() in atlas.mappings) {
 
                 // This will remap the UV coordinates of the part
                 // To 0..1 range if need be.
@@ -352,7 +352,7 @@ void incINPExportFinalizePacking(ref Puppet source, Atlas[] atlasses) {
 
                 // Now we need to scale those UV coordinates to fit within the mapping
                 float atlasSize = cast(float)atlas.textures[0].width;
-                rect mapping = atlas.mappings[part.uuid];
+                rect mapping = atlas.mappings[part.textures[0].getRuntimeUUID()];
                 foreach(ref uv; uvs) {
                     uv.x = (mapping.x+(uv.x*mapping.width))/atlasSize;
                     uv.y = (mapping.y+(uv.y*mapping.height))/atlasSize;

--- a/source/creator/panels/nodes.d
+++ b/source/creator/panels/nodes.d
@@ -21,7 +21,6 @@ import std.format;
 import std.conv;
 import i18n;
 
-
 enum SelectState {
     Init, Started, Ended
 }

--- a/source/creator/panels/nodes.d
+++ b/source/creator/panels/nodes.d
@@ -20,6 +20,7 @@ import std.string;
 import std.format;
 import std.conv;
 import i18n;
+import core.stdcpp.typeinfo;
 
 enum SelectState {
     Init, Started, Ended
@@ -165,6 +166,16 @@ protected:
                 incText(incTypeIdToIcon("MeshGroup"));
                 igSameLine(0, 2);
                 if (igMenuItem(__("MeshGroup"), "", false, true)) incAddChildWithHistory(new MeshGroup(cast(Node)null), n);
+                
+                incText(incTypeIdToIcon("Part"));
+                igSameLine(0, 2);
+                
+                if (igMenuItem(__("Duplicate"), "", false, true)) {
+                    
+                    
+                    recursiveDuplicate(n, n.parent);
+                    incActivePuppet().rescanNodes();
+                }
 
                 igEndMenu();
             }

--- a/source/creator/panels/nodes.d
+++ b/source/creator/panels/nodes.d
@@ -20,7 +20,7 @@ import std.string;
 import std.format;
 import std.conv;
 import i18n;
-import core.stdcpp.typeinfo;
+
 
 enum SelectState {
     Init, Started, Ended


### PR DESCRIPTION
This adds a basic duplication function to the nodes right click menu, which will duplicate the right clicked node and most of its children. It currently excludes duplicating cameras. There may be some missing variables that aren't copied over.

Unfortunately part duplicates still place a duplicate into the atlas and animations probably can't be duplicated yet. I'll be trying to modify the atlas export to be based on textures instead of parts but I'm not sure how yet. Animation duplication after that.