### PR TITLE
Fix macOS 15.4+ startup and release packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,15 +83,24 @@ jobs:
             os: windows-latest
 
           - platform: 'linux'
-            os: ubuntu-20.04
+            os: ubuntu-22.04
       
     steps:
     - uses: actions/checkout@v4
       with:
         ref: '${{ inputs.target_ref }}'
         
-    # Setup D Compiler
-    - uses: dlang-community/setup-dlang@v1.4.0
+    # LDC 1.41 contains the macOS 15.4 TLS runtime fix. Newer compiler releases
+    # need to be validated against Creator's Objective-C bridge before updating.
+    - name: 'Setup D compiler (macOS)'
+      if: ${{ matrix.config.platform == 'osx' }}
+      uses: dlang-community/setup-dlang@v1.4.0
+      with:
+        compiler: ldc-1.41.0
+
+    - name: 'Setup D compiler'
+      if: ${{ matrix.config.platform != 'osx' }}
+      uses: dlang-community/setup-dlang@v1.4.0
       with:
         compiler: ldc-latest
 
@@ -109,22 +118,11 @@ jobs:
 
     - name: 'Preparing build... (macOS)'
       if: ${{ matrix.config.platform == 'osx' }}
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '12.0'
       run: |
-        export HOMEBREW_NO_INSTALL_CLEANUP=1
-        export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-
-        # Remove conflicting brew items
-        brew remove --ignore-dependencies libpng brotli harfbuzz
-
-        # Delete fake harfbuzz if need be
-        if [ -f "/usr/local/lib/libharfbuzz.dylib" ]; then
-          sudo rm -r /usr/local/lib/libharfbuzz.dylib
-        fi
-
-        # And the .a for it as well
-        if [ -f "/usr/local/lib/libharfbuzz.a" ]; then
-          sudo rm -r /usr/local/lib/libharfbuzz.a
-        fi
+        ldc2 --version
+        ./build-aux/osx/smoke-test-runtime.sh ldc2
 
     - name: 'Preparing build... (Windows)'
       if: ${{ matrix.config.platform == 'win32' }}
@@ -134,9 +132,9 @@ jobs:
       
     - name: "Clone dependencies & set versions"
       run: |
-        git clone https://github.com/Inochi2D/i2d-imgui.git --recurse-submodules
-        git clone https://github.com/Inochi2D/dcv-i2d
-        dub add-local i2d-imgui/ "0.8.0"
+        git clone --branch v0.8.1 --depth 1 --recurse-submodules --shallow-submodules https://github.com/Inochi2D/i2d-imgui.git
+        git clone --depth 1 https://github.com/Inochi2D/dcv-i2d
+        dub add-local i2d-imgui/ "0.8.1"
         dub add-local dcv-i2d/ "0.3.0"
 
     - name: 'Update version info'
@@ -148,17 +146,21 @@ jobs:
     - name: 'Build (OSX Universal)'
       if: ${{ matrix.config.platform == 'osx' }}
       id: osx-build
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '12.0'
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+        CMAKE_TOOLCHAIN_FILE: '${{ github.workspace }}/build-aux/osx/universal-toolchain.cmake'
       run: |
         dub build --config=meta
 
         # First build ARM64 version...
         echo "Building arm64 binary..."
-        dub build --build=${{ inputs.build_type }} --compiler=ldc2 --config=${{ matrix.config.platform }}-${{ inputs.variant }} --arch=arm64-apple-macos
+        dub build --build=${{ inputs.build_type }} --compiler=ldc2 --config=${{ matrix.config.platform }}-${{ inputs.variant }} --arch=arm64-apple-macosx12.0.0
         mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-arm64"
 
         # Then the X86_64 version...
         echo "Building x86_64 binary..."
-        dub build --build=${{ inputs.build_type }} --compiler=ldc2 --config=${{ matrix.config.platform }}-${{ inputs.variant }} --arch=x86_64-apple-macos
+        dub build --build=${{ inputs.build_type }} --compiler=ldc2 --config=${{ matrix.config.platform }}-${{ inputs.variant }} --arch=x86_64-apple-macosx12.0.0
         mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-x86_64"
 
         # Glue them together with lipo
@@ -172,6 +174,9 @@ jobs:
         # Bundle
         echo "Bundling up to app"
         ./build-aux/osx/osxbundle.sh
+
+        echo "Validating app bundle"
+        ./build-aux/osx/validate-bundle.sh
 
     - name: 'Build (Windows)'
       if: ${{ matrix.config.platform == 'win32' }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,7 +6,7 @@ name: Pull Request Test
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "v0_8" ]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4.1.7
@@ -28,10 +28,10 @@ jobs:
       
     - name: "Clone dependencies & set versions"
       run: |
-        git clone https://github.com/Inochi2D/i2d-imgui.git --recurse-submodules
-        git clone https://github.com/Inochi2D/inochi2d.git
-        dub add-local i2d-imgui/ "0.8.0"
-        dub add-local inochi2d/ "0.8.5"
+        git clone --branch v0.8.1 --depth 1 --recurse-submodules --shallow-submodules https://github.com/Inochi2D/i2d-imgui.git
+        git clone --branch v0.8.7 --depth 1 https://github.com/Inochi2D/inochi2d.git
+        dub add-local i2d-imgui/ "0.8.1"
+        dub add-local inochi2d/ "0.8.7"
 
     - name: 'Build'
       run: |
@@ -47,7 +47,7 @@ jobs:
 
     - name: "Upload Artifacts"  
       if: success()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: inochi-creator
         path: out/inochi-creator

--- a/build-aux/osx/BuildUniversal.sh
+++ b/build-aux/osx/BuildUniversal.sh
@@ -1,14 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 # Generate version files...
 dub build --config=meta
 
 # First build ARM64 version...
 echo "Building arm64 binary..."
-dub build --build=release --config=osx-full --arch=arm64-apple-macos
+dub build --build=release --config=osx-full --arch=arm64-apple-macosx12.0.0
 mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-arm64"
 
 # Then the X86_64 version...
 echo "Building x86_64 binary..."
-dub build --build=release --config=osx-full --arch=x86_64-apple-macos
+dub build --build=release --config=osx-full --arch=x86_64-apple-macosx12.0.0
 mv "out/Inochi Creator.app/Contents/MacOS/inochi-creator" "out/Inochi Creator.app/Contents/MacOS/inochi-creator-x86_64"
 
 # Glue them together with lipo

--- a/build-aux/osx/Info.plist
+++ b/build-aux/osx/Info.plist
@@ -5,7 +5,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.4</string>
+	<string>0.0.0</string>
 	<key>CFBundleName</key>
 	<string>Inochi Creator</string>
 	<key>CFBundleDisplayName</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.inochi2d.InochiCreator</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.4</string>
+	<string>0.0.0</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>

--- a/build-aux/osx/gendmg.sh
+++ b/build-aux/osx/gendmg.sh
@@ -1,46 +1,44 @@
-DMGTITLE="Install Inochi Creator"
-DMGFILENAME="Install_Inochi_Creator.dmg"
+#!/usr/bin/env bash
+set -euo pipefail
 
-if [ -d "out/Inochi Creator.app" ]; then
-    if [ -f "out/$DMGFILENAME" ]; then
-        echo "Removing prior install dmg..."
-        rm "out/$DMGFILENAME"
-    fi
+DMG_TITLE="Install Inochi Creator"
+DMG_FILENAME="Install_Inochi_Creator.dmg"
+APP="out/Inochi Creator.app"
+EXECUTABLE="$APP/Contents/MacOS/inochi-creator"
 
-    cd out/
-    echo "Building $DMGFILENAME..."
-
-    # Create Install Volume directory
-
-    if [ -d "InstallVolume" ]; then
-        echo "Cleaning up old install volume..."
-        rm -r InstallVolume
-    fi
-
-    mkdir -p InstallVolume
-    cp ../LICENSE LICENSE
-    cp -r "Inochi Creator.app" "InstallVolume/Inochi Creator.app"
-    
-    # Downloaded artifact removes executable flag.
-    chmod +x "InstallVolume/Inochi Creator.app/Contents/MacOS/inochi-creator"
-    
-    create-dmg \
-        --volname "$DMGTITLE" \
-        --volicon "InochiCreator.icns" \
-        --background "../build-aux/osx/dmgbg.png" \
-        --window-size 800 600 \
-        --icon "Inochi Creator.app" 200 250 \
-        --hide-extension "Inochi Creator.app" \
-        --eula "LICENSE" \
-        --app-drop-link 600 250 \
-        "$DMGFILENAME" InstallVolume/
-
-    echo "Done! Cleaning up temporaries..."
-    rm LICENSE
-
-    echo "DMG generated as $PWD/$DMGFILENAME"
-    cd ..
-else
-    echo "Could not find Inochi Creator for packaging..."
+if [[ ! -d "$APP" ]]; then
+    echo "Could not find Inochi Creator for packaging" >&2
     exit 1
 fi
+
+# actions/upload-artifact intentionally normalizes file permissions. Restore
+# the executable bit and signature after the bundle is downloaded by this job.
+chmod 755 "$EXECUTABLE"
+if ! codesign --verify --deep "$APP" 2>/dev/null; then
+    xattr -cr "$APP"
+    xattr -d com.apple.FinderInfo "$APP" 2>/dev/null || true
+    codesign --force --deep --sign - "$APP"
+fi
+./build-aux/osx/validate-bundle.sh "$APP"
+
+rm -f "out/$DMG_FILENAME"
+rm -rf out/InstallVolume
+mkdir -p out/InstallVolume
+cp LICENSE out/LICENSE
+cp -R "$APP" "out/InstallVolume/Inochi Creator.app"
+./build-aux/osx/validate-bundle.sh "out/InstallVolume/Inochi Creator.app"
+
+cd out
+create-dmg \
+    --volname "$DMG_TITLE" \
+    --volicon InochiCreator.icns \
+    --background ../build-aux/osx/dmgbg.png \
+    --window-size 800 600 \
+    --icon "Inochi Creator.app" 200 250 \
+    --hide-extension "Inochi Creator.app" \
+    --eula LICENSE \
+    --app-drop-link 600 250 \
+    "$DMG_FILENAME" InstallVolume/
+
+rm LICENSE
+echo "DMG generated as $PWD/$DMG_FILENAME"

--- a/build-aux/osx/osxbundle.sh
+++ b/build-aux/osx/osxbundle.sh
@@ -1,56 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP="out/Inochi Creator.app"
+CONTENTS="$APP/Contents"
+EXECUTABLE="$CONTENTS/MacOS/inochi-creator"
+
+if [[ ! -f "$EXECUTABLE" ]]; then
+    echo "Could not find $EXECUTABLE" >&2
+    exit 1
+fi
+
 echo "Creating directory structure..."
-LASTPWD=$PWD
+rm -rf "$CONTENTS/Frameworks" "$CONTENTS/SharedSupport" "$CONTENTS/Resources"
+rm -f "$CONTENTS/Info.plist"
+mkdir -p "$CONTENTS/Frameworks" "$CONTENTS/SharedSupport" "$CONTENTS/Resources/i18n"
 
-# Handle copying all the dylibs to their respective directories
-# As well handle creating our directory structure
-cd out/Inochi\ Creator.app/Contents
+# DUB copies the dynamic dependencies beside the executable. Move them into
+# the standard bundle location before signing the finished application.
+if [[ -f "$CONTENTS/MacOS/libSDL2-2.0.dylib" ]]; then
+    mv "$CONTENTS/MacOS/libSDL2-2.0.dylib" "$CONTENTS/Frameworks/libSDL2.dylib"
+fi
+find "$CONTENTS/MacOS" -maxdepth 1 -name '*.dylib' -exec mv -n {} "$CONTENTS/Frameworks/" \;
 
-# Remove old files
-if [ -d "Frameworks" ]; then
-    echo "Removing files from prior bundle..."
-    rm -r Frameworks SharedSupport Resources
-    rm Info.plist
+cp build-aux/osx/Info.plist "$CONTENTS/Info.plist"
+
+version=""
+if [[ -s version.txt ]]; then
+    version="$(tr -d '\r\n' < version.txt)"
+fi
+if [[ -z "$version" ]]; then
+    version="$(sed -nE 's/.*INC_VERSION = "([^"]+)".*/\1/p' source/creator/ver.d | head -n 1)"
 fi
 
-# Create new directories and move dylibs
-mkdir -p Frameworks SharedSupport Resources Resources/i18n
-mv MacOS/libSDL2-2.0.dylib Frameworks/libSDL2.dylib
-mv -n MacOS/*.dylib Frameworks
-
-# Move back to where we were
-cd $LASTPWD
-
-echo "Setting up file structure..."
-
-# Copy info plist and icon
-cp build-aux/osx/Info.plist out/Inochi\ Creator.app/Contents/
-
-# Move any translation files in if any.
-mv -n out/*.mo out/Inochi\ Creator.app/Contents/Resources/i18n/
-
-# Copy license info to SharedSupport
-cp res/*-LICENSE out/Inochi\ Creator.app/Contents/SharedSupport/
-cp LICENSE out/Inochi\ Creator.app/Contents/SharedSupport/LICENSE
-
-# CI step for i18n
-if [ -d "out/i18n/" ]; then
-    echo "(CI Step) Applying translations..."
-    mv -n out/i18n/*.mo out/Inochi\ Creator.app/Contents/Resources/i18n/
+version="${version#v}"
+short_version="${version%%+*}"
+short_version="${short_version%%-*}"
+if [[ ! "$short_version" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+    echo "Invalid macOS bundle version: $short_version" >&2
+    exit 1
 fi
 
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $short_version" "$CONTENTS/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $short_version" "$CONTENTS/Info.plist"
 
-# Create icons dir
-# TODO: check if dir exists, skip this step if it does
-if [ ! -d "out/InochiCreator.icns" ]; then
+shopt -s nullglob
+translations=(out/*.mo out/i18n/*.mo)
+if (( ${#translations[@]} )); then
+    cp "${translations[@]}" "$CONTENTS/Resources/i18n/"
+fi
+shopt -u nullglob
+
+cp res/*-LICENSE "$CONTENTS/SharedSupport/"
+cp LICENSE "$CONTENTS/SharedSupport/LICENSE"
+
+if [[ ! -f out/InochiCreator.icns ]]; then
     iconutil -c icns -o out/InochiCreator.icns build-aux/osx/Inochi-Creator.iconset
-else
-    echo "Icons already exist, skipping..."
 fi
+cp out/InochiCreator.icns "$CONTENTS/Resources/InochiCreator.icns"
 
-echo "Applying Icon..."
-cp out/InochiCreator.icns out/Inochi\ Creator.app/Contents/Resources/InochiCreator.icns 
+find "$CONTENTS/MacOS" -type f ! -name 'inochi-creator' -delete
+chmod 755 "$EXECUTABLE"
 
-echo "Cleaning up..."
-find out/Inochi\ Creator.app/Contents/MacOS -type f ! -name "inochi-creator" -delete
+# LDC linker-signs the executable, but adding bundle resources invalidates that
+# partial signature. Apply a valid ad-hoc signature until release notarization
+# is configured with the project's Developer ID credentials.
+xattr -cr "$APP"
+xattr -d com.apple.FinderInfo "$APP" 2>/dev/null || true
+codesign --force --deep --sign - "$APP"
 
-echo "Done!"
+echo "Created $APP ($short_version)"

--- a/build-aux/osx/smoke-test-runtime.sh
+++ b/build-aux/osx/smoke-test-runtime.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+compiler="${1:-ldc2}"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+printf 'void main() {}\n' > "$temporary_directory/runtime_smoke.d"
+"$compiler" "$temporary_directory/runtime_smoke.d" -of="$temporary_directory/runtime-smoke"
+"$temporary_directory/runtime-smoke"
+
+echo "D runtime smoke test passed with $compiler"

--- a/build-aux/osx/universal-toolchain.cmake
+++ b/build-aux/osx/universal-toolchain.cmake
@@ -1,0 +1,8 @@
+# Inochi Creator's macOS dependencies are built as universal binaries. Optional
+# libraries installed by Homebrew or MacPorts are commonly host-architecture
+# only and must not leak into that build.
+set(CMAKE_IGNORE_PREFIX_PATH "/opt/homebrew;/usr/local;/opt/local" CACHE STRING "" FORCE)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "" FORCE)
+set(FT_DISABLE_PNG ON CACHE BOOL "" FORCE)
+set(FT_DISABLE_HARFBUZZ ON CACHE BOOL "" FORCE)
+set(FT_DISABLE_BROTLI ON CACHE BOOL "" FORCE)

--- a/build-aux/osx/validate-bundle.sh
+++ b/build-aux/osx/validate-bundle.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP="${1:-out/Inochi Creator.app}"
+CONTENTS="$APP/Contents"
+EXECUTABLE="$CONTENTS/MacOS/inochi-creator"
+
+[[ -x "$EXECUTABLE" ]] || { echo "$EXECUTABLE is not executable" >&2; exit 1; }
+plutil -lint "$CONTENTS/Info.plist"
+
+short_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$CONTENTS/Info.plist")"
+bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$CONTENTS/Info.plist")"
+[[ "$short_version" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]] || { echo "Invalid short version: $short_version" >&2; exit 1; }
+[[ "$bundle_version" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]] || { echo "Invalid bundle version: $bundle_version" >&2; exit 1; }
+
+minimum_macos="$(otool -l "$EXECUTABLE" | awk '/LC_BUILD_VERSION/{found=1} found && $1 == "minos" {print $2; exit}')"
+[[ "$minimum_macos" == '12.0' ]] || { echo "Unexpected minimum macOS version: $minimum_macos" >&2; exit 1; }
+
+while IFS= read -r macho_file; do
+    lipo "$macho_file" -verify_arch arm64 x86_64
+    if otool -L "$macho_file" | grep -E '/(opt/homebrew|usr/local|opt/local)/' >/dev/null; then
+        echo "Host package-manager dependency found in $macho_file" >&2
+        exit 1
+    fi
+done < <(find "$CONTENTS/MacOS" "$CONTENTS/Frameworks" -type f -print | while IFS= read -r candidate; do
+    if file "$candidate" | grep -q 'Mach-O'; then
+        printf '%s\n' "$candidate"
+    fi
+done)
+
+codesign --verify --deep --verbose=2 "$APP"
+echo "Validated universal macOS bundle: $APP"


### PR DESCRIPTION
## Summary

- build macOS releases with LDC 1.41.0, which includes the current-Darwin TLS runtime fix, and execute a minimal compiled program before the main build
- target macOS 12.0 explicitly for both universal slices so newer SDKs cannot stamp an incompatible future minimum OS version
- pin the compatible `i2d-imgui` v0.8.1 dependency and isolate universal FreeType/SDL builds from single-architecture Homebrew and MacPorts libraries
- restore the app executable permission, populate bundle versions from Creator's generated version, ad-hoc sign the completed bundle, and validate both the app artifact and DMG staging copy
- run pull-request checks for the active `v0_8` branch and update the retired Ubuntu/artifact-action versions

## Root cause

The v0.8.6 macOS artifact contains a D runtime that crashes in `rt.sections_darwin_64.getTLSRange` on macOS 15.4 and newer (reported in #493). The executable-permission workaround was committed one day after the v0.8.6 tag, so the release DMG also shipped its main executable as mode 0644.

There were two additional reproducibility problems: CI cloned the incompatible moving `i2d-imgui` main branch while registering it as 0.8.0, and unversioned Apple target triples can acquire the host SDK's future deployment version. On a current SDK this produced `minos 28.0`, which LaunchServices rejects even though direct execution succeeds.

LDC 1.41.0 is pinned intentionally. It contains the TLS correction and builds this branch successfully. LDC 1.42.0 currently crashes internally in Creator's Objective-C code generation on this source tree, so advancing the pin should be gated by the new runtime and bundle checks.

## Verification

Tested on arm64 macOS 27 with Xcode 26.2:

- compiled and executed the D runtime smoke test with LDC 1.41.0
- built Creator release slices for `arm64-apple-macosx12.0.0` and `x86_64-apple-macosx12.0.0`
- combined and validated the universal application and every bundled Mach-O dependency
- verified plist versions, executable mode, minimum macOS 12.0, absence of package-manager library paths, and the completed bundle signature
- generated the DMG and validated its staged application
- copied the app into `/Applications` and launched it successfully through LaunchServices to the New Project screen
- ran ShellCheck, actionlint, and `git diff --check`

Fixes #493.
