### PR TITLE
Fix #500: Path deformer's position doesn't reset when moving to the ne

### DIFF
--- a/source/creator/viewport/model/deform.d
+++ b/source/creator/viewport/model/deform.d
@@ -7,6 +7,7 @@
 module creator.viewport.model.deform;
 import creator.viewport.common.mesh;
 import creator.viewport.common.mesheditor;
+import creator.viewport.common.mesheditor.tools.pathdeform;
 import creator.widgets.tooltip;
 import creator.core.input;
 import inochi2d.core.dbg;
@@ -19,6 +20,16 @@ import i18n;
 private {
     IncMeshEditor editor;
     Drawable selected = null;
+
+    void resetPathDeformTarget(IncMeshEditorOne meshEditor) {
+        auto pathTool = cast(PathDeformTool)meshEditor.getTool();
+        if (pathTool is null || pathTool.getMode() != PathDeformTool.Mode.Transform)
+            return;
+
+        auto path = pathTool.path;
+        if (path !is null && path.target !is null)
+            meshEditor.createPathTarget();
+    }
 }
 
 void incViewportNodeDeformNotifyParamValueChanged() {
@@ -47,6 +58,7 @@ void incViewportNodeDeformNotifyParamValueChanged() {
                     e.applyOffsets(binding.vertexOffsets[]);
                 }
                 e.adjustPathTransform();
+                resetPathDeformTarget(e);
             }
         }
     } else {


### PR DESCRIPTION
Fixes #500

## Implementation summary

Reset the transient Path Deform target spline when the armed parameter value changes. After the destination keypoint deformation and path-coordinate adjustment are applied, Transform Path now rebuilds its target from the base path instead of carrying the previous keypoint's transformed target forward.

## Changes

```
source/creator/viewport/model/deform.d | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

Testing

- "dpkg-query"/"apt-cache" checks for "libfreetype-dev", "libfreetype6-dev", and "libsdl2-dev" — passed: Confirmed that "libfreetype-dev" 2.13.2 and "libsdl2-dev" 2.30.0 are installed. The CMake failure is not caused by missing required development libraries, but by i2d-imgui 0.8.1's lowercase FreeType package lookup.
- "/usr/bin/ldc2 -c source/creator/viewport/model/deform.d -of=out/review/deform.o <DUB import/string-import/version arguments>" — passed: The modified "deform.d" compiled successfully using the Linux-full dependency import paths and version settings, producing a valid x86-64 ELF object.
- "DUB_HOME="$PWD/.review-dub" dub add-local review-deps/i2d-imgui-v0.8.0 0.8.0" — passed: Registered i2d-imgui v0.8.0 as a local dependency in the validation-only DUB environment.
- "DUB_HOME="$PWD/.review-dub" PATH=/usr/bin:/bin:$PATH /usr/bin/dub build --config=meta" — passed: The metadata build succeeded in the validation environment with i2d-imgui 0.8.0 selected.
- "DUB_HOME="$PWD/.review-dub" PATH=/usr/bin:/bin:$PATH DFLAGS='-L-lz' /usr/bin/dub build --compiler=/usr/bin/ldc2 --build=release --config=linux-full" — passed: After explicitly providing the existing zlib linker flag required by the host environment, the full Linux-full release compilation and final "inochi-creator" link succeeded.
- "git diff --check" — passed: The validation snapshot intentionally has an empty Git index, so it cannot be used to track changes themselves, but no whitespace errors were reported.
- "python3 structural assertions for PathDeform import, Transform-mode guard, non-null target guard, createPathTarget reuse, and call ordering" — passed: Confirmed that the helper applies only when the active tool is "PathDeform", requires Transform mode and an existing non-null target, and calls "createPathTarget()" after "adjustPathTransform()".
- "python3 exact additive-diff assertion against upstream v0_8 deform.d" — passed: Confirmed exactly that no existing upstream lines were deleted or modified and that only the expected 12 lines were added.